### PR TITLE
Partially rewrite JsonApi\Hydrator to improve performance

### DIFF
--- a/src/JsonApi/Hydrator.php
+++ b/src/JsonApi/Hydrator.php
@@ -2,13 +2,11 @@
 
 namespace Swis\JsonApi\Client\JsonApi;
 
-use Art4\JsonApiClient\AccessInterface;
+use Art4\JsonApiClient\ElementInterface;
 use Art4\JsonApiClient\ResourceCollectionInterface;
-use Art4\JsonApiClient\ResourceCollectionInterface as JsonApiCollection;
-use Art4\JsonApiClient\ResourceIdentifierCollection as IdentifierCollection;
 use Art4\JsonApiClient\ResourceIdentifierCollectionInterface;
 use Art4\JsonApiClient\ResourceIdentifierInterface;
-use Art4\JsonApiClient\ResourceItemInterface as JsonApItem;
+use Art4\JsonApiClient\ResourceItemInterface;
 use Swis\JsonApi\Client\Collection;
 use Swis\JsonApi\Client\Interfaces\ItemInterface;
 use Swis\JsonApi\Client\Interfaces\TypeMapperInterface;
@@ -20,7 +18,7 @@ class Hydrator
     /**
      * @var \Swis\JsonApi\Client\Interfaces\TypeMapperInterface
      */
-    private $typeMapper;
+    protected $typeMapper;
 
     /**
      * @param \Swis\JsonApi\Client\Interfaces\TypeMapperInterface $typeMapper
@@ -31,11 +29,29 @@ class Hydrator
     }
 
     /**
+     * @param \Art4\JsonApiClient\ResourceItemInterface $jsonApiItem
+     *
+     * @return \Swis\JsonApi\Client\Interfaces\ItemInterface
+     */
+    public function hydrateItem(ResourceItemInterface $jsonApiItem): ItemInterface
+    {
+        $item = $this->getItemClass($jsonApiItem->get('type'));
+
+        $item->setId($jsonApiItem->get('id'));
+
+        if ($jsonApiItem->has('attributes')) {
+            $item->fill($jsonApiItem->get('attributes')->asArray(true));
+        }
+
+        return $item;
+    }
+
+    /**
      * @param \Art4\JsonApiClient\ResourceCollectionInterface $jsonApiCollection
      *
      * @return \Swis\JsonApi\Client\Collection
      */
-    public function hydrateCollection(JsonApiCollection $jsonApiCollection)
+    public function hydrateCollection(ResourceCollectionInterface $jsonApiCollection): Collection
     {
         $collection = new Collection();
         foreach ($jsonApiCollection->asArray() as $item) {
@@ -46,83 +62,44 @@ class Hydrator
     }
 
     /**
-     * @param \Art4\JsonApiClient\ResourceItemInterface $jsonApiItem
-     *
-     * @return \Swis\JsonApi\Client\Interfaces\ItemInterface
-     */
-    public function hydrateItem(JsonApItem $jsonApiItem)
-    {
-        $item = $this->getItemClass($jsonApiItem);
-
-        $item->setType($jsonApiItem->get('type'))
-            ->setId($jsonApiItem->get('id'));
-
-        $this->hydrateAttributes($jsonApiItem, $item);
-
-        return $item;
-    }
-
-    /**
-     * @param \Art4\JsonApiClient\ResourceItemInterface $jsonApiItem
-     *
-     * @return \Swis\JsonApi\Client\Interfaces\ItemInterface
-     */
-    protected function getItemClass(JsonApItem $jsonApiItem): ItemInterface
-    {
-        $type = $jsonApiItem->get('type');
-        if ($this->typeMapper->hasMapping($type)) {
-            return $this->typeMapper->getMapping($type);
-        }
-
-        return new JenssegersItem();
-    }
-
-    /**
-     * @param \Art4\JsonApiClient\ResourceItemInterface     $jsonApiItem
-     * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $item
-     */
-    protected function hydrateAttributes(JsonApItem $jsonApiItem, ItemInterface $item)
-    {
-        if ($jsonApiItem->has('attributes')) {
-            $item->fill($jsonApiItem->get('attributes')->asArray(true));
-        }
-    }
-
-    /**
      * @param \Swis\JsonApi\Client\Collection $jsonApiItems
      * @param \Swis\JsonApi\Client\Collection $items
      */
     public function hydrateRelationships(Collection $jsonApiItems, Collection $items)
     {
+        $keyedItems = $items->keyBy(
+            function (ItemInterface $item) {
+                return $this->getItemKey($item);
+            }
+        );
+
         $jsonApiItems->each(
-            function (JsonApItem $jsonApiItem) use ($items) {
+            function (ResourceItemInterface $jsonApiItem) use ($keyedItems) {
                 if (!$jsonApiItem->has('relationships')) {
                     return;
                 }
 
-                $item = $this->getIncludedItem($items, $jsonApiItem);
+                $item = $this->getItem($keyedItems, $jsonApiItem);
 
                 if ($item instanceof NullItem) {
                     return;
                 }
 
-                $relationships = $this->getJsonApiDocumentRelationships($jsonApiItem);
-
-                foreach ($relationships as $name => $relationship) {
-                    /** @var \Art4\JsonApiClient\ResourceItemInterface $data */
+                foreach ($jsonApiItem->get('relationships')->asArray() as $name => $relationship) {
+                    /** @var \Art4\JsonApiClient\ElementInterface $data */
                     $data = $relationship->get('data');
                     $method = camel_case($name);
 
                     if ($data instanceof ResourceIdentifierInterface) {
-                        $includedItem = $this->getIncludedItem($items, $data);
+                        $includedItem = $this->getItem($keyedItems, $data);
 
                         if ($includedItem instanceof NullItem) {
                             continue;
                         }
 
                         $item->setRelation($method, $includedItem);
-                    } elseif ($data instanceof ResourceCollectionInterface || $data instanceof ResourceIdentifierCollectionInterface) {
-                        $collection = $this->getIncludedItems($items, $data);
+                    } elseif ($data instanceof ResourceIdentifierCollectionInterface) {
+                        $collection = $this->getCollection($keyedItems, $data);
 
                         $item->setRelation($method, $collection);
                     }
@@ -132,72 +109,75 @@ class Hydrator
     }
 
     /**
-     * @param \Art4\JsonApiClient\ResourceItemInterface $jsonApiItem
-     *
-     * @return \Art4\JsonApiClient\Relationship[]
-     */
-    protected function getJsonApiDocumentRelationships(JsonApItem $jsonApiItem): array
-    {
-        return $jsonApiItem->get('relationships')->asArray(false);
-    }
-
-    /**
-     * @param \Swis\JsonApi\Client\Collection     $included
-     * @param \Art4\JsonApiClient\AccessInterface $accessor
+     * @param string $type
      *
      * @return \Swis\JsonApi\Client\Interfaces\ItemInterface
      */
-    protected function getIncludedItem(Collection $included, AccessInterface $accessor): ItemInterface
+    protected function getItemClass(string $type): ItemInterface
     {
-        return $included->first(
-            function (ItemInterface $item) use ($accessor) {
-                return $this->accessorBelongsToItem($accessor, $item);
-            },
-            new NullItem()
+        if ($this->typeMapper->hasMapping($type)) {
+            return $this->typeMapper->getMapping($type);
+        }
+
+        return (new JenssegersItem())->setType($type);
+    }
+
+    /**
+     * @param \Swis\JsonApi\Client\Collection                                                           $included
+     * @param \Art4\JsonApiClient\ResourceIdentifierInterface|\Art4\JsonApiClient\ResourceItemInterface $identifier
+     *
+     * @return \Swis\JsonApi\Client\Interfaces\ItemInterface
+     */
+    protected function getItem(Collection $included, $identifier): ItemInterface
+    {
+        return $included->get(
+            $this->getElementKey($identifier),
+            function () {
+                return new NullItem();
+            }
         );
     }
 
     /**
-     * @param \Art4\JsonApiClient\AccessInterface           $accessor
-     * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $item
-     *
-     * @return bool
-     */
-    protected function accessorBelongsToItem(AccessInterface $accessor, ItemInterface $item): bool
-    {
-        return $item->getType() === $accessor->get('type')
-            && (string)$item->getId() === $accessor->get('id');
-    }
-
-    /**
-     * @param \Swis\JsonApi\Client\Collection                  $included
-     * @param \Art4\JsonApiClient\ResourceIdentifierCollection $collection
+     * @param \Swis\JsonApi\Client\Collection                                                                           $included
+     * @param \Art4\JsonApiClient\ResourceIdentifierCollectionInterface|\Art4\JsonApiClient\ResourceCollectionInterface $identifierCollection
      *
      * @return \Swis\JsonApi\Client\Collection
      */
-    protected function getIncludedItems(Collection $included, IdentifierCollection $collection): Collection
+    protected function getCollection(Collection $included, $identifierCollection): Collection
     {
-        return $included->filter(
-            function (ItemInterface $item) use ($collection) {
-                return $this->itemExistsInRelatedIdentifiers($collection->asArray(false), $item);
+        $items = new Collection();
+
+        foreach ($identifierCollection->asArray() as $identifier) {
+            $item = $this->getItem($included, $identifier);
+
+            if ($item instanceof NullItem) {
+                continue;
             }
-        )->values();
+
+            $items->push($item);
+        }
+
+        return $items;
     }
 
     /**
-     * @param \Art4\JsonApiClient\ResourceIdentifier[]      $relatedIdentifiers
      * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $item
      *
-     * @return bool
+     * @return string
      */
-    protected function itemExistsInRelatedIdentifiers(array $relatedIdentifiers, ItemInterface $item): bool
+    protected function getItemKey(ItemInterface $item): string
     {
-        foreach ($relatedIdentifiers as $relatedIdentifier) {
-            if ($this->accessorBelongsToItem($relatedIdentifier, $item)) {
-                return true;
-            }
-        }
+        return sprintf('%s:%s', $item->getType(), $item->getId());
+    }
 
-        return false;
+    /**
+     * @param \Art4\JsonApiClient\ElementInterface $accessor
+     *
+     * @return string
+     */
+    protected function getElementKey(ElementInterface $accessor): string
+    {
+        return sprintf('%s:%s', $accessor->get('type'), $accessor->get('id'));
     }
 }

--- a/tests/JsonApi/HydratorTest.php
+++ b/tests/JsonApi/HydratorTest.php
@@ -54,8 +54,8 @@ class HydratorTest extends AbstractTest
         $typeMapper->method('hasMapping')->willReturn(true);
         $typeMapper->method('getMapping')->will(
             $this->returnCallback(
-                function () {
-                    return new JenssegersItem();
+                function (string $type) {
+                    return (new JenssegersItem())->setType($type);
                 }
             )
         );


### PR DESCRIPTION
## Description

I (partially) rewrote the JsonApi\Hydrator to improve the performance.

## Motivation and context

Hydrating a document with 2.000 items with relationships took about five minutes. After this change it is reduced to around two seconds. 🎉 

Performance was improved by using a 'lookup table' to find the hydrated items instead of looping over all items for every relationship e.g. 2.000 * 2.000.

## How has this been tested?

This has been tested/profiled in a private project with timings from laravel-debugbar. Please see this [example json](https://github.com/swisnl/json-api-client/files/2062295/slow.txt).

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.
