### PR TITLE
Do not add attributes to item when empty

### DIFF
--- a/src/Items/JenssegersItem.php
+++ b/src/Items/JenssegersItem.php
@@ -60,12 +60,14 @@ class JenssegersItem extends Model implements ItemInterface
             $data['id'] = $this->getId();
         }
 
-        if (!empty($this->getAttributes())) {
-            $data['attributes'] = $this->toArray();
+        $attributes = $this->toArray();
+        if (!empty($attributes)) {
+            $data['attributes'] = $attributes;
         }
 
-        if (!empty($this->getRelationships())) {
-            $data['relationships'] = $this->getRelationships();
+        $relationships = $this->getRelationships();
+        if (!empty($relationships)) {
+            $data['relationships'] = $relationships;
         }
 
         return $data;

--- a/tests/Items/JenssegersItemTest.php
+++ b/tests/Items/JenssegersItemTest.php
@@ -5,6 +5,7 @@ namespace Swis\JsonApi\Client\Tests\Items;
 use Swis\JsonApi\Client\Items\JenssegersItem;
 use Swis\JsonApi\Client\Tests\AbstractTest;
 use Swis\JsonApi\Client\Tests\Mocks\Items\Jenssegers\WithGetMutatorJenssegersItem;
+use Swis\JsonApi\Client\Tests\Mocks\Items\Jenssegers\WithHiddenJenssegersItem;
 
 class JenssegersItemTest extends AbstractTest
 {
@@ -150,5 +151,23 @@ class JenssegersItemTest extends AbstractTest
         $item->setRelation('someRelation', (new JenssegersItem())->setType('type')->setId(1));
 
         $this->assertTrue($item->hasRelationship('some_relation'));
+    }
+
+    /**
+     * @test
+     */
+    public function is_does_not_show_attributes_in_to_json_api_array_when_it_has_no_attributes()
+    {
+        $item = new WithHiddenJenssegersItem($this->attributes);
+        $item->setType('testType');
+        $item->setId(1234);
+
+        $this->assertEquals(
+            [
+                'type' => 'testType',
+                'id'   => 1234,
+            ],
+            $item->toJsonApiArray()
+        );
     }
 }

--- a/tests/_mocks/Items/Jenssegers/WithHiddenJenssegersItem.php
+++ b/tests/_mocks/Items/Jenssegers/WithHiddenJenssegersItem.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Swis\JsonApi\Client\Tests\Mocks\Items\Jenssegers;
+
+use Swis\JsonApi\Client\Items\JenssegersItem;
+
+class WithHiddenJenssegersItem extends JenssegersItem
+{
+    protected $hidden = [
+        'testKey',
+    ];
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I check if the attributes array is empty before we add it to the JSON API array. This was done before, but it didn't account for hidden or appended attributes.

## Motivation and context

In some cases, the `toJsonApiArray` method in `JenssegersItem` added an empty attributes array to the array. After JSON encoding this resulted in a JSON array, whilst the attributes must be an object according to the spec. If the attributes are empty, the attributes section can be omitted (see http://jsonapi.org/format/#document-resource-objects).

## How has this been tested?

I created an extra test to verify the above behaviour.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.
