### PR TITLE
Include attributes in get relationships

### DIFF
--- a/src/Items/JenssegersItem.php
+++ b/src/Items/JenssegersItem.php
@@ -145,7 +145,6 @@ class JenssegersItem extends Model implements ItemInterface
                         'id'   => $relationship->getId(),
                     ],
                 ];
-
             } elseif ($relationship instanceof HasManyRelation) {
                 $relationships[$name]['data'] = [];
 
@@ -156,7 +155,6 @@ class JenssegersItem extends Model implements ItemInterface
                     ];
                     $relationships[$name]['data'][] = $data + $item->getAttributes();
                 }
-
             } elseif ($relationship instanceof MorphToRelation) {
                 $relationships[$name]['data'] = [];
                 $data = [
@@ -164,7 +162,6 @@ class JenssegersItem extends Model implements ItemInterface
                     'id'   => $relationship->getIncluded()->getId(),
                 ];
                 $relationships[$name]['data'] = $data + $relationship->getIncluded()->getAttributes();
-
             } elseif ($relationship instanceof MorphToManyRelation) {
                 $relationships[$name]['data'] = [];
 
@@ -180,7 +177,6 @@ class JenssegersItem extends Model implements ItemInterface
 
         return $relationships;
     }
-
 
     /**
      * @TODO: MEGA TODO. Set up a serializer for the Item so that we can remove this, getRelationships etc

--- a/src/Items/JenssegersItem.php
+++ b/src/Items/JenssegersItem.php
@@ -145,38 +145,42 @@ class JenssegersItem extends Model implements ItemInterface
                         'id'   => $relationship->getId(),
                     ],
                 ];
+
             } elseif ($relationship instanceof HasManyRelation) {
                 $relationships[$name]['data'] = [];
 
                 foreach ($relationship->getIncluded() as $item) {
-                    $relationships[$name]['data'][] =
-                        [
-                            'type' => $relationship->getType(),
-                            'id'   => $item->getId(),
-                        ];
+                    $data = [
+                        'type' => $relationship->getType(),
+                        'id'   => $item->getId(),
+                    ];
+                    $relationships[$name]['data'][] = $data + $item->getAttributes();
                 }
+
             } elseif ($relationship instanceof MorphToRelation) {
-                $relationships[$name] = [
-                    'data' => [
-                        'type' => $relationship->getIncluded()->getType(),
-                        'id'   => $relationship->getIncluded()->getId(),
-                    ],
+                $relationships[$name]['data'] = [];
+                $data = [
+                    'type' => $relationship->getIncluded()->getType(),
+                    'id'   => $relationship->getIncluded()->getId(),
                 ];
+                $relationships[$name]['data'] = $data + $relationship->getIncluded()->getAttributes();
+
             } elseif ($relationship instanceof MorphToManyRelation) {
                 $relationships[$name]['data'] = [];
 
                 foreach ($relationship->getIncluded() as $item) {
-                    $relationships[$name]['data'][] =
-                        [
-                            'type' => $item->getType(),
-                            'id'   => $item->getId(),
-                        ];
+                    $data = [
+                        'type' => $item->getType(),
+                        'id'   => $item->getId(),
+                    ];
+                    $relationships[$name]['data'][] = $data + $item->getAttributes();
                 }
             }
         }
 
         return $relationships;
     }
+
 
     /**
      * @TODO: MEGA TODO. Set up a serializer for the Item so that we can remove this, getRelationships etc

--- a/src/JsonApi/Hydrator.php
+++ b/src/JsonApi/Hydrator.php
@@ -63,26 +63,27 @@ class Hydrator
 
     /**
      * @param $jsonApiCollection
+     *
      * @return Collection
      */
     public function hydrateRelationCollection($jsonApiCollection): Collection
     {
         $collection = new Collection();
         foreach ($jsonApiCollection->asArray() as $item) {
-            $returnItem=$this->hydrateRelationItem($item);
-            if($returnItem instanceof Collection)
-            {
-                $collection=  $collection->merge($returnItem);
-            }else{
+            $returnItem = $this->hydrateRelationItem($item);
+            if ($returnItem instanceof Collection) {
+                $collection = $collection->merge($returnItem);
+            } else {
                 $collection->push($this->hydrateRelationItem($item));
-
             }
         }
+
         return $collection;
     }
 
     /**
      * @param $jsonApiItem
+     *
      * @return null|Collection|ItemInterface
      */
     public function hydrateRelationItem($jsonApiItem)
@@ -93,18 +94,17 @@ class Hydrator
         } elseif ($jsonApiItem->has('data.0.type')) {
             $collection = new Collection();
 
-            foreach ($jsonApiItem->get('data')->getKeys() as $key)
-            {
+            foreach ($jsonApiItem->get('data')->getKeys() as $key) {
                 $item = $this->getItemClass($jsonApiItem->get('data.'.$key.'.type'));
                 $item->setId($jsonApiItem->get('data.'.$key.'.id'));
                 $collection->push($item);
-
             }
+
             return $collection;
         }
+
         return $item ?? null;
     }
-
 
     /**
      * @param \Swis\JsonApi\Client\Collection $jsonApiItems
@@ -119,7 +119,7 @@ class Hydrator
         );
 
         $jsonApiItems->each(
-            function ( $jsonApiItem) use ($keyedItems) {
+            function ($jsonApiItem) use ($keyedItems) {
                 if (!$jsonApiItem->has('relationships')) {
                     return;
                 }

--- a/src/JsonApi/Parser.php
+++ b/src/JsonApi/Parser.php
@@ -13,7 +13,6 @@ use Swis\JsonApi\Client\Errors\ErrorCollection;
 use Swis\JsonApi\Client\Interfaces\DocumentInterface;
 use Swis\JsonApi\Client\Interfaces\ParserInterface;
 use Swis\JsonApi\Client\ItemDocument;
-use Swis\JsonApi\Client\Items\JenssegersItem;
 
 class Parser implements ParserInterface
 {
@@ -99,6 +98,7 @@ class Parser implements ParserInterface
      *
      * @throws \DomainException
      *includedInDocument
+     *
      * @return \Swis\JsonApi\Client\Interfaces\DocumentInterface
      */
     protected function buildDataDocument(Art4JsonApiDocumentInterface $jsonApiDocument): DocumentInterface
@@ -139,7 +139,6 @@ class Parser implements ParserInterface
             if ($includedInDocument) {
                 $newRelationships = new Collection();
                 foreach ($relationships as $relationship) {
-
                     $id = $relationship->getId();
                     $type = $relationship->getType();
                     $desiredObject = null;
@@ -157,8 +156,7 @@ class Parser implements ParserInterface
             }
         }
 
-
-            //$allHydratedItems Items will be in response
+        //$allHydratedItems Items will be in response
         $this->hydrator->hydrateRelationships($allJsonApiItems, $allHydratedItems);
         if ($included) {
             $document->setIncluded($included);
@@ -166,7 +164,6 @@ class Parser implements ParserInterface
 
         return $document;
     }
-
 
     /**
      * @param \Art4\JsonApiClient\DocumentInterface $document
@@ -210,9 +207,9 @@ class Parser implements ParserInterface
         if ($document->has('data.relationships')) {
             return $document->get('data.relationships');
         }
+
         return null;
     }
-
 
     /**
      * @param \Art4\JsonApiClient\DocumentInterface $document
@@ -224,6 +221,7 @@ class Parser implements ParserInterface
         if (!$document->has('links')) {
             return [];
         }
+
         return $document->get('links')->asArray(true);
     }
 

--- a/src/JsonApi/Parser.php
+++ b/src/JsonApi/Parser.php
@@ -136,25 +136,29 @@ class Parser implements ParserInterface
 
         if ($relationshipsInDocument) {
             $relationships = $this->hydrator->hydrateRelationCollection($relationshipsInDocument);
-            $newRelationships=new Collection();
-            foreach ($relationships as $relationship) {
+            if ($includedInDocument) {
+                $newRelationships = new Collection();
+                foreach ($relationships as $relationship) {
 
-                $id = $relationship->getId();
-                $type = $relationship->getType();
-                $desired_object = null;
-                $desired_object = $included->first(function ($item) use ($id, $type) {
-                    return ($item->getId() == $id) && ($item->getType() == $type);
-                });
-                if (is_null($desired_object)) {
-                    $newRelationships->push($relationship);
+                    $id = $relationship->getId();
+                    $type = $relationship->getType();
+                    $desiredObject = null;
+
+                    //check duplicate
+                    $desiredObject = $included->first(function ($item) use ($id, $type) {
+                        return ($item->getId() == $id) && ($item->getType() == $type);
+                    });
+                    if (is_null($desiredObject)) {
+                        $newRelationships->push($relationship);
+                    }
                 }
+            } else {
+                $newRelationships = $relationships;
             }
-
-            $allHydratedItems = $allHydratedItems->concat($newRelationships);
-            $allJsonApiItems = $allJsonApiItems->concat(new Collection($relationshipsInDocument->asArray()));
         }
 
-        //$allHydratedItems Items will be in response
+
+            //$allHydratedItems Items will be in response
         $this->hydrator->hydrateRelationships($allJsonApiItems, $allHydratedItems);
         if ($included) {
             $document->setIncluded($included);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This will allow you to set laravel validation rules on include attributes.

## Motivation and context
 What problem does it solve?
there wasn't a way to set validation rules on jsonapi include object's attributes, because of includes is an array of index objects, and you don't know what is the order of relation include objects. 

## How has this been tested?

Run the tests to make sure that everything still works.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [ x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x ] My pull request addresses exactly one patch/feature.
- [ x] I have created a branch for this patch/feature.
- [x ] Each individual commit in the pull request is meaningful.
- [x ] I have added tests to cover my changes.
- [x ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
