### PR TITLE
Allow '0' as id in ItemDocumentBuilder

### DIFF
--- a/src/ItemDocumentBuilder.php
+++ b/src/ItemDocumentBuilder.php
@@ -22,7 +22,7 @@ class ItemDocumentBuilder
     /**
      * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $item
      * @param array                                         $attributes
-     * @param string                                        $id
+     * @param string|null                                   $id
      *
      * @return \Swis\JsonApi\Client\ItemDocument
      */
@@ -30,7 +30,7 @@ class ItemDocumentBuilder
     {
         $this->itemHydrator->hydrate($item, $attributes);
 
-        if ($id) {
+        if ($id !== null && $id !== '') {
             $item->setId($id);
         }
 

--- a/tests/ItemDocumentBuilderTest.php
+++ b/tests/ItemDocumentBuilderTest.php
@@ -20,11 +20,59 @@ class ItemDocumentBuilderTest extends AbstractTest
         $itemHydrator = new ItemHydrator($typeMapper);
         $itemDocumentBuilder = new ItemDocumentBuilder($itemHydrator);
 
-        $itemDocument = $itemDocumentBuilder->build(new Item(), $data, 123);
+        $itemDocument = $itemDocumentBuilder->build(new Item(), $data, '123');
 
         $item = $itemDocument->getData();
         static::assertInstanceOf(Item::class, $item);
+        static::assertEquals($item->getId(), '123');
         static::assertEquals($item->key1, $data['key1']);
         static::assertEquals($item->key2, $data['key2']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_fills_items_without_id()
+    {
+        $typeMapper = new TypeMapper();
+        $itemHydrator = new ItemHydrator($typeMapper);
+        $itemDocumentBuilder = new ItemDocumentBuilder($itemHydrator);
+
+        $itemDocument = $itemDocumentBuilder->build(new Item(), []);
+
+        $item = $itemDocument->getData();
+        static::assertInstanceOf(Item::class, $item);
+        static::assertNull($item->getId());
+    }
+
+    /**
+     * @test
+     * @dataProvider provideIdArguments
+     *
+     * @param $givenId
+     * @param $expectedId
+     */
+    public function it_fills_the_id_when_not_null_or_empty_string($givenId, $expectedId)
+    {
+        $typeMapper = new TypeMapper();
+        $itemHydrator = new ItemHydrator($typeMapper);
+        $itemDocumentBuilder = new ItemDocumentBuilder($itemHydrator);
+
+        $itemDocument = $itemDocumentBuilder->build(new Item(), [], $givenId);
+
+        $item = $itemDocument->getData();
+        static::assertInstanceOf(Item::class, $item);
+        static::assertSame($item->getId(), $expectedId);
+    }
+
+    public function provideIdArguments(): array
+    {
+        return [
+            ['0', '0'],
+            ['12', '12'],
+            ['foo-bar', 'foo-bar'],
+            [null, null],
+            ['', null],
+        ];
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allow '0' as id in ItemDocumentBuilder.

## Motivation and context

Id '0' was not possible when using the ItemDocumentBuilder, but the spec does not forbid this: https://jsonapi.org/format/#document-resource-object-identification

## How has this been tested?

Tested using (added) unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
