### PR TITLE
Do not fill type attribute in unmapped items in morph(to) relationships

### DIFF
--- a/src/ItemHydrator.php
+++ b/src/ItemHydrator.php
@@ -152,11 +152,12 @@ class ItemHydrator
      */
     protected function hydrateMorphToRelation(array $attributes, MorphToRelation $relation, string $availableRelation)
     {
-        if (!array_key_exists('type', $attributes[$availableRelation])) {
+        $relationData = $attributes[$availableRelation];
+        if (!array_key_exists('type', $relationData)) {
             throw new \InvalidArgumentException('Always provide a "type" attribute in a morphTo relationship');
         }
+        $relationItem = $this->buildRelationItem($relation, array_diff_key($relationData, ['type' => 'type']), $relationData['type']);
 
-        $relationItem = $this->buildRelationItem($relation, $attributes[$availableRelation], $attributes[$availableRelation]['type']);
         $relation->associate($relationItem);
     }
 
@@ -173,7 +174,7 @@ class ItemHydrator
             if (!array_key_exists('type', $relationData)) {
                 throw new \InvalidArgumentException('Always provide a "type" attribute in a morphToMany relationship entry');
             }
-            $relationItem = $this->buildRelationItem($relation, $relationData, $relationData['type']);
+            $relationItem = $this->buildRelationItem($relation, array_diff_key($relationData, ['type' => 'type']), $relationData['type']);
 
             $relation->associate($relation->getIncluded()->push($relationItem));
         }

--- a/tests/ItemHydratorTest.php
+++ b/tests/ItemHydratorTest.php
@@ -185,11 +185,36 @@ class ItemHydratorTest extends AbstractTest
         $this->assertEquals($data['testattribute1'], $item->getAttribute('testattribute1'));
         $this->assertEquals($data['testattribute2'], $item->getAttribute('testattribute2'));
         $this->assertEquals('related-item', $morphTo->getType());
+        $this->assertEquals('related-item', $morphTo->getIncluded()->getType());
         $this->assertEquals(
             $data['morphto_relation']['test_related_attribute1'],
             $morphTo->getIncluded()->getAttribute('test_related_attribute1')
         );
         $this->assertArrayHasKey('morphto_relation', $item->toJsonApiArray()['relationships']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_hydrates_unmapped_items_with_morphto_relationship()
+    {
+        $data = [
+            'morphto_relation' => [
+                'id'                      => 1,
+                'type'                    => 'unmapped-item',
+                'test_related_attribute1' => 'test',
+            ],
+        ];
+
+        $item = new WithRelationshipItem();
+        $item = $this->getItemHydrator()->hydrate($item, $data);
+
+        /** @var \Swis\JsonApi\Client\Relations\MorphToRelation $morphTo */
+        $morphTo = $item->getRelationship('morphto_relation');
+
+        $this->assertEquals('unmapped-item', $morphTo->getType());
+        $this->assertEquals('unmapped-item', $morphTo->getIncluded()->getType());
+        $this->assertArrayNotHasKey('type', $morphTo->getIncluded()->getAttributes());
     }
 
     /**
@@ -263,6 +288,38 @@ class ItemHydratorTest extends AbstractTest
             $morphToMany->getIncluded()[1]->getAttribute('test_related_attribute1')
         );
         $this->assertArrayHasKey('morphtomany_relation', $item->toJsonApiArray()['relationships']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_hydrates_unmapped_items_with_morphtomany_relationship()
+    {
+        $data = [
+            'morphtomany_relation' => [
+                [
+                    'id'                      => 1,
+                    'type'                    => 'unmapped-item',
+                    'test_related_attribute1' => 'test1',
+                ],
+                [
+                    'id'                      => 2,
+                    'type'                    => 'unmapped-item',
+                    'test_related_attribute1' => 'test2',
+                ],
+            ],
+        ];
+
+        $item = new WithRelationshipItem();
+        $item = $this->getItemHydrator()->hydrate($item, $data);
+
+        /** @var \Swis\JsonApi\Client\Relations\MorphToManyRelation $morphToMany */
+        $morphToMany = $item->getRelationship('morphtomany_relation');
+
+        $this->assertEquals('unmapped-item', $morphToMany->getIncluded()[0]->getType());
+        $this->assertEquals('unmapped-item', $morphToMany->getIncluded()[1]->getType());
+        $this->assertArrayNotHasKey('type', $morphToMany->getIncluded()[0]->getAttributes());
+        $this->assertArrayNotHasKey('type', $morphToMany->getIncluded()[1]->getAttributes());
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I changed the ItemHydrator to omit the 'type' attribute when filling the attributes for an unmapped item.

## Motivation and context

Without this fix, this resulted in items with 'type' attributes, which violates the spec.: https://jsonapi.org/format/#document-resource-object-fields

## How has this been tested?

Tested with new unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
