### PR TITLE
Align CollectionDocument(Interface) with ItemDocument(Interface)

### DIFF
--- a/src/CollectionDocument.php
+++ b/src/CollectionDocument.php
@@ -4,50 +4,6 @@ namespace Swis\JsonApi\Client;
 
 use Swis\JsonApi\Client\Interfaces\CollectionDocumentInterface;
 
-class CollectionDocument extends Document implements CollectionDocumentInterface, \JsonSerializable
+class CollectionDocument extends Document implements CollectionDocumentInterface
 {
-    /**
-     * Specify data which should be serialized to JSON.
-     *
-     * @see  http://php.net/manual/en/jsonserializable.jsonserialize.php
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
-     *
-     * @since 5.4.0
-     */
-    public function jsonSerialize()
-    {
-        return $this->toArray();
-    }
-
-    /**
-     * @return array
-     */
-    public function toArray(): array
-    {
-        $document = [];
-
-        if (!empty($this->getLinks())) {
-            $document['links'] = $this->links;
-        }
-
-        if (!empty($this->getData())) {
-            $document['data'] = $this->data->toJsonApiArray();
-        }
-
-        if (!empty($this->getMeta())) {
-            $document['meta'] = $this->meta;
-        }
-
-        if ($this->hasErrors()) {
-            $document['errors'] = $this->errors->toArray();
-        }
-
-        if (!empty($this->getJsonapi())) {
-            $document['jsonapi'] = $this->jsonapi;
-        }
-
-        return $document;
-    }
 }

--- a/src/Document.php
+++ b/src/Document.php
@@ -6,7 +6,7 @@ use Swis\JsonApi\Client\Errors\ErrorCollection;
 use Swis\JsonApi\Client\Interfaces\DataInterface;
 use Swis\JsonApi\Client\Interfaces\DocumentInterface;
 
-class Document implements DocumentInterface
+class Document implements DocumentInterface, \JsonSerializable
 {
     /**
      * @var \Swis\JsonApi\Client\Interfaces\DataInterface
@@ -154,5 +154,54 @@ class Document implements DocumentInterface
         $this->data = $data;
 
         return $this;
+    }
+
+    /**
+     * Specify data which should be serialized to JSON.
+     *
+     * @see  http://php.net/manual/en/jsonserializable.jsonserialize.php
+     *
+     * @return mixed data which can be serialized by <b>json_encode</b>,
+     *               which is a value of any type other than a resource
+     *
+     * @since 5.4.0
+     */
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray(): array
+    {
+        $document = [];
+
+        if (!empty($this->getLinks())) {
+            $document['links'] = $this->links;
+        }
+
+        if (!empty($this->getData())) {
+            $document['data'] = $this->data->toJsonApiArray();
+        }
+
+        if ($this->getIncluded()->isNotEmpty()) {
+            $document['included'] = $this->getIncluded()->toJsonApiArray();
+        }
+
+        if (!empty($this->getMeta())) {
+            $document['meta'] = $this->meta;
+        }
+
+        if ($this->hasErrors()) {
+            $document['errors'] = $this->errors->toArray();
+        }
+
+        if (!empty($this->getJsonapi())) {
+            $document['jsonapi'] = $this->jsonapi;
+        }
+
+        return $document;
     }
 }

--- a/src/Interfaces/DocumentInterface.php
+++ b/src/Interfaces/DocumentInterface.php
@@ -18,6 +18,11 @@ interface DocumentInterface
     public function getErrors(): ErrorCollection;
 
     /**
+     * @return bool
+     */
+    public function hasErrors(): bool;
+
+    /**
      * @return mixed
      */
     public function getMeta(): array;
@@ -38,7 +43,7 @@ interface DocumentInterface
     public function getJsonapi();
 
     /**
-     * @return bool
+     * @return array
      */
-    public function hasErrors(): bool;
+    public function toArray(): array;
 }

--- a/src/Interfaces/ItemDocumentInterface.php
+++ b/src/Interfaces/ItemDocumentInterface.php
@@ -8,9 +8,4 @@ interface ItemDocumentInterface extends DocumentInterface
      * @return \Swis\JsonApi\Client\Interfaces\ItemInterface
      */
     public function getData();
-
-    /**
-     * @return array
-     */
-    public function toArray();
 }

--- a/src/InvalidResponseDocument.php
+++ b/src/InvalidResponseDocument.php
@@ -24,6 +24,14 @@ class InvalidResponseDocument implements DocumentInterface
     }
 
     /**
+     * @return bool
+     */
+    public function hasErrors(): bool
+    {
+        return false;
+    }
+
+    /**
      * @return mixed
      */
     public function getMeta(): array
@@ -56,10 +64,10 @@ class InvalidResponseDocument implements DocumentInterface
     }
 
     /**
-     * @return bool
+     * @return array
      */
-    public function hasErrors(): bool
+    public function toArray(): array
     {
-        return false;
+        return [];
     }
 }

--- a/src/ItemDocument.php
+++ b/src/ItemDocument.php
@@ -4,54 +4,6 @@ namespace Swis\JsonApi\Client;
 
 use Swis\JsonApi\Client\Interfaces\ItemDocumentInterface;
 
-class ItemDocument extends Document implements ItemDocumentInterface, \JsonSerializable
+class ItemDocument extends Document implements ItemDocumentInterface
 {
-    /**
-     * Specify data which should be serialized to JSON.
-     *
-     * @see  http://php.net/manual/en/jsonserializable.jsonserialize.php
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
-     *
-     * @since 5.4.0
-     */
-    public function jsonSerialize()
-    {
-        return $this->toArray();
-    }
-
-    /**
-     * @return array
-     */
-    public function toArray(): array
-    {
-        $document = [];
-
-        if (!empty($this->getLinks())) {
-            $document['links'] = $this->links;
-        }
-
-        if (!empty($this->getData())) {
-            $document['data'] = $this->data->toJsonApiArray();
-        }
-
-        if (!empty($this->getIncluded())) {
-            $document['included'] = $this->getIncluded()->toJsonApiArray();
-        }
-
-        if (!empty($this->getMeta())) {
-            $document['meta'] = $this->meta;
-        }
-
-        if ($this->hasErrors()) {
-            $document['errors'] = $this->errors->toArray();
-        }
-
-        if (!empty($this->getJsonapi())) {
-            $document['jsonapi'] = $this->jsonapi;
-        }
-
-        return $document;
-    }
 }

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Swis\JsonApi\Client\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Swis\JsonApi\Client\Collection;
+use Swis\JsonApi\Client\Document;
+use Swis\JsonApi\Client\Errors\ErrorCollection;
+use Swis\JsonApi\Client\Item;
+
+class DocumentTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_only_filled_properties_in_toArray()
+    {
+        $document = new Document();
+
+        $this->assertEquals([], $document->toArray());
+
+        $document->setLinks(
+            [
+                'self' => 'http://example.com/articles',
+                'next' => 'http://example.com/articles?page[offset]=2',
+                'last' => 'http://example.com/articles?page[offset]=10',
+            ]
+        );
+        $document->setData(
+            (new Item(['title' => 'JSON:API paints my bikeshed!']))
+                ->setType('articles')
+                ->setId(1)
+        );
+        $document->setIncluded(
+            new Collection(
+                [
+                    (new Item(['firstName' => 'Dan', 'lastName' => 'Gebhardt', 'twitter' => 'dgeb']))
+                        ->setType('people')
+                        ->setId(9),
+                ]
+            )
+        );
+        $document->setMeta(['copyright' => 'Copyright 2015 Example Corp.']);
+        $document->setErrors(
+            new ErrorCollection(
+                [
+                    ['id' => 'error-1'],
+                ]
+            )
+        );
+        $document->setJsonapi(['version' => '1.0']);
+
+        $this->assertEquals(
+            [
+                'links'    => [
+                    'self' => 'http://example.com/articles',
+                    'next' => 'http://example.com/articles?page[offset]=2',
+                    'last' => 'http://example.com/articles?page[offset]=10',
+                ],
+                'data'     => [
+                    'type'       => 'articles',
+                    'id'         => 1,
+                    'attributes' => [
+                        'title' => 'JSON:API paints my bikeshed!',
+                    ],
+                ],
+                'included' => [
+                    [
+                        'type'       => 'people',
+                        'id'         => 9,
+                        'attributes' => [
+                            'firstName' => 'Dan',
+                            'lastName'  => 'Gebhardt',
+                            'twitter'   => 'dgeb',
+                        ],
+                    ],
+                ],
+                'meta' => [
+                    'copyright' => 'Copyright 2015 Example Corp.',
+                ],
+                'errors' => [
+                    [
+                        'id' => 'error-1',
+                    ],
+                ],
+                'jsonapi' => [
+                    'version' => '1.0',
+                ],
+            ],
+            $document->toArray()
+        );
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I moved the jsonSerialize and toArray methods from `CollectionDocument` and `ItemDocument` to `Document` because they can (and should) be similar.

## Motivation and context

This improves the code quality and fixes #31 

## How has this been tested?

Tested using existing and added unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
