### PR TITLE
Skip relationships without data

### DIFF
--- a/src/JsonApi/Hydrator.php
+++ b/src/JsonApi/Hydrator.php
@@ -85,6 +85,10 @@ class Hydrator
                 }
 
                 foreach ($jsonApiItem->get('relationships')->asArray() as $name => $relationship) {
+                    if (!$relationship->has('data')) {
+                        continue;
+                    }
+
                     /** @var \Art4\JsonApiClient\ElementInterface $data */
                     $data = $relationship->get('data');
                     $method = camel_case($name);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fix makes sure the hydrator doesn't fail if a relationship has no data.

## Motivation and context

According to the spec, a document does not have to include data in the relationship; https://jsonapi.org/format/#document-resource-object-relationships

Fixes #35 

## How has this been tested?

Tested using new unit test.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
