### PR TITLE
add isSuccess method to Document

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -101,6 +101,14 @@ class Document implements DocumentInterface
     }
 
     /**
+     * @return bool
+     */
+    public function isSuccess(): bool
+    {
+        return $this->errors->isEmpty();
+    }
+
+    /**
      * @return \Swis\JsonApi\Client\Collection
      */
     public function getIncluded(): Collection

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -13,6 +13,26 @@ class DocumentTest extends TestCase
     /**
      * @test
      */
+    public function it_knows_if_hasErrors()
+    {
+        $document = new Document();
+        $this->assertEquals($document->isSuccess(), true);
+        $this->assertEquals($document->hasErrors(), false);
+
+        $document->setErrors(
+          new ErrorCollection(
+              [
+                  ['id' => 'error-1'],
+              ]
+          )
+      );
+        $this->assertEquals($document->hasErrors(), true);
+        $this->assertEquals($document->isSuccess(), false);
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_only_filled_properties_in_toArray()
     {
         $document = new Document();


### PR DESCRIPTION
just for alternative usage of else/if statement after document initialization

allows hadle success block in if statement in more readable way


before
```
if !($document->hasErrors()){ ... }
```

after

```
if $document->isSuccess() { ... }
```


## Description

add new method to Document class

## Motivation and context

allows to check Document instance is successful 

## How has this been tested?

Unit test


