### PR TITLE
Do not throw exceptions in Repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Add headers to request methods in `DocumentClientInterface`.
 N.B. This is a breaking change if you implement the interface yourself or extend the `DocumentClient`. [#34](https://github.com/swisnl/json-api-client/pull/34)
+* `Repository` doesn't throw exceptions anymore.
+N.B. This is a breaking change if you catch `DocumentNotFoundException` or `DocumentTypeException`. If you would like the old behaviour, you can simply extend the `Repository` and implement it yourself.
 
 ### Removed
 
 * Removed obsolete `ItemDocumentSerializer` in favor of `JsonSerializable`.
 N.B. This is a breaking change if you use this class directly, construct the `DocumentClient` yourself or have overwritten `\Swis\JsonApi\Client\Providers\ServiceProvider::registerClients`. The `ItemDocument` can now be serialized using its `jsonSerialize` method.
+* Removed obsolete `DocumentNotFoundException` and `DocumentTypeException`.
+N.B. This is a breaking change if you catch these exceptions.
 
 ### Fixed
 

--- a/README.MD
+++ b/README.MD
@@ -45,46 +45,23 @@ If you are using Laravel < 5.5 or have disabled package auto discover, you must 
 
 ## Getting started
 
-You can simply require the client as a dependency and use it in your class.
-This allows you to, for example, make a repository that uses the [DocumentClient](#documentclient):
+You can simply require the [DocumentClient](#documentclient) as a dependency and use it in your class.
+Alternatively, you can create a repository based on `\Swis\JsonApi\Client\Repository`:
 
 ``` php
-use Swis\JsonApi\Client\Interfaces\DocumentClientInterface;
-use Swis\JsonApi\Client\Interfaces\ItemDocumentInterface;
+use Swis\JsonApi\Client\Repository
 
-class BlogRepository
+class BlogRepository extends Repository
 {
-    protected $client;
+    protected $endpoint = 'blogs';
+}
 
-    public function __construct(DocumentClientInterface $client)
-    {
-        $this->client = $client;
-    }
-
-    public function all(array $parameters = [])
-    {
-        return $this->client->get('blogs?'.http_build_query($parameters));
-    }
-
-    public function create(ItemDocumentInterface $document, array $parameters = [])
-    {
-        return $this->client->post('blogs?'.http_build_query($parameters), $document);
-    }
-
-    public function find(string $id, array $parameters = [])
-    {
-        return $this->client->get('blogs/'.urlencode($id).'?'.http_build_query($parameters));
-    }
-
-    public function update(ItemDocumentInterface $document, array $parameters = [])
-    {
-        return $this->client->patch('blogs/'.urlencode($document->getData()->getId()).'?'.http_build_query($parameters), $document);
-    }
-
-    public function delete(string $id, array $parameters = [])
-    {
-        return $this->client->delete('blogs/'.urlencode($id).'?'.http_build_query($parameters));
-    }
+$repository = new BlogRepository();
+$document = $repository->all();
+if ($document->hasErrors()) {
+   // do something with errors
+} else {
+  $blogs = $document->getData();
 }
 ```
 

--- a/src/Exceptions/DocumentNotFoundException.php
+++ b/src/Exceptions/DocumentNotFoundException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Swis\JsonApi\Client\Exceptions;
-
-class DocumentNotFoundException extends \Exception
-{
-}

--- a/src/Exceptions/DocumentTypeException.php
+++ b/src/Exceptions/DocumentTypeException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Swis\JsonApi\Client\Exceptions;
-
-class DocumentTypeException extends \Exception
-{
-}

--- a/src/Interfaces/RepositoryInterface.php
+++ b/src/Interfaces/RepositoryInterface.php
@@ -5,16 +5,12 @@ namespace Swis\JsonApi\Client\Interfaces;
 interface RepositoryInterface
 {
     /**
-     * @throws \Swis\JsonApi\Client\Exceptions\DocumentTypeException
-     *
      * @return \Swis\JsonApi\Client\Interfaces\CollectionDocumentInterface
      */
     public function all();
 
     /**
      * @param $id
-     *
-     * @throws \Swis\JsonApi\Client\Exceptions\DocumentTypeException
      *
      * @return \Swis\JsonApi\Client\Interfaces\ItemDocumentInterface
      */

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -2,9 +2,6 @@
 
 namespace Swis\JsonApi\Client;
 
-use Swis\JsonApi\Client\Exceptions\DocumentNotFoundException;
-use Swis\JsonApi\Client\Exceptions\DocumentTypeException;
-use Swis\JsonApi\Client\Interfaces\CollectionDocumentInterface;
 use Swis\JsonApi\Client\Interfaces\DocumentClientInterface;
 use Swis\JsonApi\Client\Interfaces\ItemDocumentInterface;
 use Swis\JsonApi\Client\Interfaces\RepositoryInterface;
@@ -30,26 +27,6 @@ class Repository implements RepositoryInterface
     }
 
     /**
-     * @param array $parameters
-     *
-     * @throws \Swis\JsonApi\Client\Exceptions\DocumentTypeException
-     *
-     * @return \Swis\JsonApi\Client\Interfaces\CollectionDocumentInterface
-     */
-    public function all(array $parameters = [])
-    {
-        $document = $this->getClient()->get($this->getEndpoint().'?'.http_build_query($parameters));
-
-        if (!$document instanceof CollectionDocumentInterface) {
-            throw new DocumentTypeException(
-                sprintf('Expected %s got %s', CollectionDocumentInterface::class, get_class($document))
-            );
-        }
-
-        return $document;
-    }
-
-    /**
      * @return \Swis\JsonApi\Client\Interfaces\DocumentClientInterface
      */
     public function getClient()
@@ -66,28 +43,24 @@ class Repository implements RepositoryInterface
     }
 
     /**
+     * @param array $parameters
+     *
+     * @return \Swis\JsonApi\Client\Interfaces\DocumentInterface
+     */
+    public function all(array $parameters = [])
+    {
+        return $this->getClient()->get($this->getEndpoint().'?'.http_build_query($parameters));
+    }
+
+    /**
      * @param       $id
      * @param array $parameters
      *
-     * @throws \Swis\JsonApi\Client\Exceptions\DocumentNotFoundException
-     * @throws \Swis\JsonApi\Client\Exceptions\DocumentTypeException
-     *
-     * @return \Swis\JsonApi\Client\Interfaces\ItemDocumentInterface
+     * @return \Swis\JsonApi\Client\Interfaces\DocumentInterface
      */
     public function find($id, array $parameters = [])
     {
-        $document = $this->getClient()->get($this->getEndpoint().'/'.urlencode($id).'?'.http_build_query($parameters));
-
-        if (null === $document->getData()) {
-            throw new DocumentNotFoundException();
-        }
-        if (!$document instanceof ItemDocumentInterface) {
-            throw new DocumentTypeException(
-                sprintf('Expected %s got %s', ItemDocumentInterface::class, get_class($document))
-            );
-        }
-
-        return $document;
+        return $this->getClient()->get($this->getEndpoint().'/'.urlencode($id).'?'.http_build_query($parameters));
     }
 
     /**
@@ -100,9 +73,9 @@ class Repository implements RepositoryInterface
     {
         if ($document->getData()->isNew()) {
             return $this->saveNew($document, $parameters);
-        } else {
-            return $this->saveExisting($document, $parameters);
         }
+
+        return $this->saveExisting($document, $parameters);
     }
 
     /**

--- a/tests/RepositoryTest.php
+++ b/tests/RepositoryTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Swis\JsonApi\Client\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Swis\JsonApi\Client\Document;
+use Swis\JsonApi\Client\Interfaces\DocumentClientInterface;
+use Swis\JsonApi\Client\Item;
+use Swis\JsonApi\Client\ItemDocument;
+use Swis\JsonApi\Client\Tests\Mocks\MockRepository;
+
+class RepositoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_can_get_the_client()
+    {
+        /** @var \PHPUnit\Framework\MockObject\MockObject|\Swis\JsonApi\Client\Interfaces\DocumentClientInterface $client */
+        $client = $this->getMockBuilder(DocumentClientInterface::class)->getMock();
+        $repository = new MockRepository($client);
+
+        $this->assertSame($client, $repository->getClient());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_the_endpoint()
+    {
+        /** @var \PHPUnit\Framework\MockObject\MockObject|\Swis\JsonApi\Client\Interfaces\DocumentClientInterface $client */
+        $client = $this->getMockBuilder(DocumentClientInterface::class)->getMock();
+        $repository = new MockRepository($client);
+
+        $this->assertSame('mocks', $repository->getEndpoint());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_all()
+    {
+        $document = new Document();
+
+        /** @var \PHPUnit\Framework\MockObject\MockObject|\Swis\JsonApi\Client\Interfaces\DocumentClientInterface $client */
+        $client = $this->getMockBuilder(DocumentClientInterface::class)->getMock();
+
+        $client->expects($this->once())
+            ->method('get')
+            ->with('mocks?foo=bar')
+            ->willReturn($document);
+
+        $repository = new MockRepository($client);
+
+        $this->assertSame($document, $repository->all(['foo' => 'bar']));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_find_one()
+    {
+        $document = new Document();
+
+        /** @var \PHPUnit\Framework\MockObject\MockObject|\Swis\JsonApi\Client\Interfaces\DocumentClientInterface $client */
+        $client = $this->getMockBuilder(DocumentClientInterface::class)->getMock();
+
+        $client->expects($this->once())
+            ->method('get')
+            ->with('mocks/1?foo=bar')
+            ->willReturn($document);
+
+        $repository = new MockRepository($client);
+
+        $this->assertSame($document, $repository->find(1, ['foo' => 'bar']));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_save_new()
+    {
+        $document = new ItemDocument();
+        $document->setData(new Item());
+
+        /** @var \PHPUnit\Framework\MockObject\MockObject|\Swis\JsonApi\Client\Interfaces\DocumentClientInterface $client */
+        $client = $this->getMockBuilder(DocumentClientInterface::class)->getMock();
+
+        $client->expects($this->once())
+            ->method('post')
+            ->with('mocks?foo=bar')
+            ->willReturn($document);
+
+        $repository = new MockRepository($client);
+
+        $this->assertSame($document, $repository->save($document, ['foo' => 'bar']));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_save_existing()
+    {
+        $document = new ItemDocument();
+        $document->setData((new Item())->setId(1));
+
+        /** @var \PHPUnit\Framework\MockObject\MockObject|\Swis\JsonApi\Client\Interfaces\DocumentClientInterface $client */
+        $client = $this->getMockBuilder(DocumentClientInterface::class)->getMock();
+
+        $client->expects($this->once())
+            ->method('patch')
+            ->with('mocks/1?foo=bar')
+            ->willReturn($document);
+
+        $repository = new MockRepository($client);
+
+        $this->assertSame($document, $repository->save($document, ['foo' => 'bar']));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_delete()
+    {
+        $document = new ItemDocument();
+        $document->setData((new Item())->setId(1));
+
+        /** @var \PHPUnit\Framework\MockObject\MockObject|\Swis\JsonApi\Client\Interfaces\DocumentClientInterface $client */
+        $client = $this->getMockBuilder(DocumentClientInterface::class)->getMock();
+
+        $client->expects($this->once())
+            ->method('delete')
+            ->with('mocks/1?foo=bar')
+            ->willReturn($document);
+
+        $repository = new MockRepository($client);
+
+        $this->assertSame($document, $repository->delete($document, ['foo' => 'bar']));
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_delete_by_id()
+    {
+        $document = new Document();
+
+        /** @var \PHPUnit\Framework\MockObject\MockObject|\Swis\JsonApi\Client\Interfaces\DocumentClientInterface $client */
+        $client = $this->getMockBuilder(DocumentClientInterface::class)->getMock();
+
+        $client->expects($this->once())
+            ->method('delete')
+            ->with('mocks/1?foo=bar')
+            ->willReturn($document);
+
+        $repository = new MockRepository($client);
+
+        $this->assertSame($document, $repository->deleteById(1, ['foo' => 'bar']));
+    }
+}

--- a/tests/_mocks/MockRepository.php
+++ b/tests/_mocks/MockRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Swis\JsonApi\Client\Tests\Mocks;
+
+use Swis\JsonApi\Client\Repository;
+
+class MockRepository extends Repository
+{
+    protected $endpoint = 'mocks';
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I removed the exceptions from `Repository` and added tests for it.

## Motivation and context

The repository only throwd exceptions in some use cases (GET requests) which was not consistent with other use cases. Besides, the repository consumer might want to handle errors differently, but because of the current implementation, he/she has no access to the underlying document. By removing the exceptions, the consumer can implement any check he/she wants. The old behaviour can be recreated by simply extending the repository and implementing the checks yourself. This closes #39.

## How has this been tested?

Tested using new unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
