### PR TITLE
 Make sure dissociating a related item results in valid JSON 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 N.B. This is a breaking change if you implement the interface yourself or extend the `DocumentClient`. [#34](https://github.com/swisnl/json-api-client/pull/34)
 * `Repository` doesn't throw exceptions anymore. [#41](https://github.com/swisnl/json-api-client/pull/41)
 N.B. This is a breaking change if you catch `DocumentNotFoundException` or `DocumentTypeException`. If you would like the old behaviour, you can simply extend the `Repository` and implement it yourself.
+* A HasOne or MorphTo relation do not set a `[relationship]_id` field on the parent when associating a related item.
 
 ### Removed
 
@@ -27,6 +28,7 @@ N.B. This is a breaking change if you catch these exceptions.
 ### Fixed
 
 * Do not fail on, but skip relationships without data [#38](https://github.com/swisnl/json-api-client/pull/38)
+* Dissociating a related item now produces valid JSON
 
 ## [0.11.0] - 2018-12-21
 

--- a/src/Item.php
+++ b/src/Item.php
@@ -316,7 +316,7 @@ class Item extends Model implements ItemInterface
         $itemType = (new $class())->getType();
 
         if (!array_key_exists($relationName, $this->relationships)) {
-            $this->relationships[$relationName] = new HasOneRelation($itemType, $this);
+            $this->relationships[$relationName] = new HasOneRelation($itemType);
         }
 
         return $this->relationships[$relationName];
@@ -354,7 +354,7 @@ class Item extends Model implements ItemInterface
         $relationName = $relationName ?: snake_case(debug_backtrace()[1]['function']);
 
         if (!array_key_exists($relationName, $this->relationships)) {
-            $this->relationships[$relationName] = new MorphToRelation($this);
+            $this->relationships[$relationName] = new MorphToRelation();
         }
 
         return $this->relationships[$relationName];

--- a/src/Item.php
+++ b/src/Item.php
@@ -138,12 +138,16 @@ class Item extends Model implements ItemInterface
         /** @var \Swis\JsonApi\Client\Interfaces\RelationInterface $relationship */
         foreach ($this->relationships as $name => $relationship) {
             if ($relationship instanceof HasOneRelation) {
-                $relationships[$name] = [
-                    'data' => [
-                        'type' => $relationship->getType(),
-                        'id'   => $relationship->getId(),
-                    ],
-                ];
+                $relationships[$name] = ['data' => null];
+
+                if ($relationship->getIncluded() !== null) {
+                    $relationships[$name] = [
+                        'data' => [
+                            'type' => $relationship->getType(),
+                            'id'   => $relationship->getId(),
+                        ],
+                    ];
+                }
             } elseif ($relationship instanceof HasManyRelation) {
                 $relationships[$name]['data'] = [];
 
@@ -155,12 +159,16 @@ class Item extends Model implements ItemInterface
                         ];
                 }
             } elseif ($relationship instanceof MorphToRelation) {
-                $relationships[$name] = [
-                    'data' => [
-                        'type' => $relationship->getIncluded()->getType(),
-                        'id'   => $relationship->getIncluded()->getId(),
-                    ],
-                ];
+                $relationships[$name] = ['data' => null];
+
+                if ($relationship->getIncluded() !== null) {
+                    $relationships[$name] = [
+                        'data' => [
+                            'type' => $relationship->getIncluded()->getType(),
+                            'id'   => $relationship->getIncluded()->getId(),
+                        ],
+                    ];
+                }
             } elseif ($relationship instanceof MorphToManyRelation) {
                 $relationships[$name]['data'] = [];
 
@@ -300,6 +308,18 @@ class Item extends Model implements ItemInterface
     public function hasRelationship(string $name): bool
     {
         return array_key_exists($name, $this->relationships);
+    }
+
+    /**
+     * @param $name
+     *
+     * @return static
+     */
+    public function removeRelationship(string $name)
+    {
+        unset($this->relationships[$name]);
+
+        return $this;
     }
 
     /**

--- a/src/Relations/AbstractOneRelation.php
+++ b/src/Relations/AbstractOneRelation.php
@@ -8,7 +8,7 @@ use Swis\JsonApi\Client\Interfaces\ItemInterface;
 abstract class AbstractOneRelation extends AbstractRelation
 {
     /**
-     * @var \Swis\JsonApi\Client\Interfaces\ItemInterface
+     * @var \Swis\JsonApi\Client\Interfaces\ItemInterface|null
      */
     protected $included;
 
@@ -33,7 +33,6 @@ abstract class AbstractOneRelation extends AbstractRelation
         }
 
         $this->setId($included->getId());
-        $this->setType($included->getType());
 
         $this->included = $included;
 
@@ -45,6 +44,8 @@ abstract class AbstractOneRelation extends AbstractRelation
      */
     public function dissociate()
     {
+        $this->setId(null);
+
         $this->included = null;
 
         return $this;

--- a/src/Relations/AbstractRelation.php
+++ b/src/Relations/AbstractRelation.php
@@ -29,7 +29,7 @@ abstract class AbstractRelation implements RelationInterface
     }
 
     /**
-     * @return string|null
+     * @return string
      */
     public function getType(): string
     {

--- a/src/Relations/HasOneRelation.php
+++ b/src/Relations/HasOneRelation.php
@@ -2,53 +2,13 @@
 
 namespace Swis\JsonApi\Client\Relations;
 
-use Swis\JsonApi\Client\Interfaces\DataInterface;
-use Swis\JsonApi\Client\Interfaces\ItemInterface;
-
 class HasOneRelation extends AbstractOneRelation
 {
     /**
-     * @var \Swis\JsonApi\Client\Interfaces\ItemInterface
+     * @param string $type
      */
-    protected $parentItem;
-
-    /**
-     * @param string                                        $type
-     * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $item
-     */
-    public function __construct(string $type, ItemInterface $item)
+    public function __construct(string $type)
     {
         $this->type = $type;
-        $this->parentItem = $item;
-    }
-
-    /**
-     * @param \Swis\JsonApi\Client\Interfaces\DataInterface $included
-     *
-     * @throws \InvalidArgumentException
-     *
-     * @return $this
-     */
-    public function associate(DataInterface $included)
-    {
-        $result = parent::associate($included);
-
-        // Set the $relation.'_id' on the parent
-        $this->parentItem->setAttribute($this->type.'_id', $this->getId());
-
-        return $result;
-    }
-
-    /**
-     * @return $this
-     */
-    public function dissociate()
-    {
-        $result = parent::dissociate();
-
-        // Remove the $relation.'_id' on the parent
-        $this->parentItem->setAttribute($this->type.'_id', null);
-
-        return $result;
     }
 }

--- a/src/Relations/MorphToRelation.php
+++ b/src/Relations/MorphToRelation.php
@@ -2,20 +2,6 @@
 
 namespace Swis\JsonApi\Client\Relations;
 
-use Swis\JsonApi\Client\Interfaces\ItemInterface;
-
 class MorphToRelation extends AbstractOneRelation
 {
-    /**
-     * @var \Swis\JsonApi\Client\Interfaces\ItemInterface
-     */
-    protected $parentItem;
-
-    /**
-     * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $item
-     */
-    public function __construct(ItemInterface $item)
-    {
-        $this->parentItem = $item;
-    }
 }

--- a/src/Relations/MorphToRelation.php
+++ b/src/Relations/MorphToRelation.php
@@ -2,6 +2,33 @@
 
 namespace Swis\JsonApi\Client\Relations;
 
+use Swis\JsonApi\Client\Interfaces\DataInterface;
+
 class MorphToRelation extends AbstractOneRelation
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function associate(DataInterface $included)
+    {
+        parent::associate($included);
+
+        /* @var \Swis\JsonApi\Client\Interfaces\ItemInterface $included */
+
+        $this->type = $included->getType();
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function dissociate()
+    {
+        parent::dissociate();
+
+        $this->type = null;
+
+        return $this;
+    }
 }

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -2,9 +2,12 @@
 
 namespace Swis\JsonApi\Client\Tests;
 
+use Swis\JsonApi\Client\Collection;
 use Swis\JsonApi\Client\Item;
+use Swis\JsonApi\Client\Tests\Mocks\Items\RelatedItem;
 use Swis\JsonApi\Client\Tests\Mocks\Items\WithGetMutatorItem;
 use Swis\JsonApi\Client\Tests\Mocks\Items\WithHiddenItem;
+use Swis\JsonApi\Client\Tests\Mocks\Items\WithRelationshipItem;
 
 class ItemTest extends AbstractTest
 {
@@ -165,6 +168,206 @@ class ItemTest extends AbstractTest
             [
                 'type' => 'testType',
                 'id'   => 1234,
+            ],
+            $item->toJsonApiArray()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function is_adds_hasone_relation_in_to_json_api_array()
+    {
+        $item = new WithRelationshipItem();
+        $item->setId(1234);
+        $item->hasoneRelation()->associate((new RelatedItem())->setId(5678));
+
+        $this->assertEquals(
+            [
+                'type'          => 'item-with-relationship',
+                'id'            => 1234,
+                'relationships' => [
+                    'hasone_relation' => [
+                        'data' => [
+                            'type' => 'related-item',
+                            'id'   => 5678,
+                        ],
+                    ],
+                ],
+            ],
+            $item->toJsonApiArray()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function is_adds_empty_hasone_relation_in_to_json_api_array()
+    {
+        $item = new WithRelationshipItem();
+        $item->setId(1234);
+        $item->hasoneRelation()->dissociate();
+
+        $this->assertEquals(
+            [
+                'type'          => 'item-with-relationship',
+                'id'            => 1234,
+                'relationships' => [
+                    'hasone_relation' => [
+                        'data' => null,
+                    ],
+                ],
+            ],
+            $item->toJsonApiArray()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function is_adds_morphto_relation_in_to_json_api_array()
+    {
+        $item = new WithRelationshipItem();
+        $item->setId(1234);
+        $item->morphtoRelation()->associate((new RelatedItem())->setId(5678));
+
+        $this->assertEquals(
+            [
+                'type'          => 'item-with-relationship',
+                'id'            => 1234,
+                'relationships' => [
+                    'morphto_relation' => [
+                        'data' => [
+                            'type' => 'related-item',
+                            'id'   => 5678,
+                        ],
+                    ],
+                ],
+            ],
+            $item->toJsonApiArray()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function is_adds_empty_morphto_relation_in_to_json_api_array()
+    {
+        $item = new WithRelationshipItem();
+        $item->setId(1234);
+        $item->morphtoRelation()->dissociate();
+
+        $this->assertEquals(
+            [
+                'type'          => 'item-with-relationship',
+                'id'            => 1234,
+                'relationships' => [
+                    'morphto_relation' => [
+                        'data' => null,
+                    ],
+                ],
+            ],
+            $item->toJsonApiArray()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function is_adds_hasmany_relation_in_to_json_api_array()
+    {
+        $item = new WithRelationshipItem();
+        $item->setId(1234);
+        $item->hasmanyRelation()->associate(new Collection([(new RelatedItem())->setId(5678)]));
+
+        $this->assertEquals(
+            [
+                'type'          => 'item-with-relationship',
+                'id'            => 1234,
+                'relationships' => [
+                    'hasmany_relation' => [
+                        'data' => [
+                            [
+                                'type' => 'related-item',
+                                'id'   => 5678,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $item->toJsonApiArray()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function is_adds_empty_hasmany_relation_in_to_json_api_array()
+    {
+        $item = new WithRelationshipItem();
+        $item->setId(1234);
+        $item->hasmanyRelation()->dissociate();
+
+        $this->assertEquals(
+            [
+                'type'          => 'item-with-relationship',
+                'id'            => 1234,
+                'relationships' => [
+                    'hasmany_relation' => [
+                        'data' => [],
+                    ],
+                ],
+            ],
+            $item->toJsonApiArray()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function is_adds_morphtomany_relation_in_to_json_api_array()
+    {
+        $item = new WithRelationshipItem();
+        $item->setId(1234);
+        $item->morphtomanyRelation()->associate(new Collection([(new RelatedItem())->setId(5678)]));
+
+        $this->assertEquals(
+            [
+                'type'          => 'item-with-relationship',
+                'id'            => 1234,
+                'relationships' => [
+                    'morphtomany_relation' => [
+                        'data' => [
+                            [
+                                'type' => 'related-item',
+                                'id'   => 5678,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            $item->toJsonApiArray()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function is_adds_empty_morphtomany_relation_in_to_json_api_array()
+    {
+        $item = new WithRelationshipItem();
+        $item->setId(1234);
+        $item->morphtomanyRelation()->dissociate();
+
+        $this->assertEquals(
+            [
+                'type'          => 'item-with-relationship',
+                'id'            => 1234,
+                'relationships' => [
+                    'morphtomany_relation' => [
+                        'data' => [],
+                    ],
+                ],
             ],
             $item->toJsonApiArray()
         );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I changed the serialization logic so it produces valid JSON when dissociating related items and I removed setting an `[relationship]_id` attribute when associating a related item.

## Motivation and context

Dissociating a related item results in invalid JSON as discussed in #36. Besides, the HasOne relation sets a  `[relationship]_id` field on the parent when associating a related item, but this is not required according to the spec. This fixes #36.

## How has this been tested?

Tested using existing and new unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
