### PR TITLE
Fix hydrating of HasOne relations by id using ItemHydrator

### DIFF
--- a/src/ItemHydrator.php
+++ b/src/ItemHydrator.php
@@ -71,9 +71,9 @@ class ItemHydrator
 
             // It is a valid relation
             if ($relation instanceof HasOneRelation) {
-                $this->hydrateHasOneRelation($item, $attributes, $relation, $availableRelation);
+                $this->hydrateHasOneRelation($attributes, $relation, $availableRelation);
             } elseif ($relation instanceof HasManyRelation) {
-                $this->hydrateHasManyRelation($attributes, $availableRelation, $relation);
+                $this->hydrateHasManyRelation($attributes, $relation, $availableRelation);
             } elseif ($relation instanceof MorphToRelation) {
                 $this->hydrateMorphToRelation($attributes, $relation, $availableRelation);
             } elseif ($relation instanceof MorphToManyRelation) {
@@ -101,26 +101,21 @@ class ItemHydrator
     }
 
     /**
-     * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $item
      * @param array                                         $attributes
      * @param \Swis\JsonApi\Client\Relations\HasOneRelation $relation
      * @param string                                        $availableRelation
      *
      * @throws \InvalidArgumentException
      */
-    protected function hydrateHasOneRelation(
-        ItemInterface $item,
-        array $attributes,
-        HasOneRelation $relation,
-        string $availableRelation
-    ) {
+    protected function hydrateHasOneRelation(array $attributes, HasOneRelation $relation, string $availableRelation)
+    {
         if (is_array($attributes[$availableRelation])) {
             $relationItem = $this->buildRelationItem($relation, $attributes[$availableRelation]);
-            $relation->associate($relationItem);
         } else {
-            $relation->setId($attributes[$availableRelation]);
-            $item->setAttribute($availableRelation.'_id', $attributes[$availableRelation]);
+            $relationItem = $this->buildRelationItem($relation, ['id' => $attributes[$availableRelation]]);
         }
+
+        $relation->associate($relationItem);
     }
 
     /**
@@ -130,7 +125,7 @@ class ItemHydrator
      *
      * @throws \InvalidArgumentException
      */
-    protected function hydrateHasManyRelation(array $attributes, string $availableRelation, HasManyRelation $relation)
+    protected function hydrateHasManyRelation(array $attributes, HasManyRelation $relation, string $availableRelation)
     {
         foreach ($attributes[$availableRelation] as $relationData) {
             if (is_array($relationData)) {

--- a/tests/ItemHydratorTest.php
+++ b/tests/ItemHydratorTest.php
@@ -18,23 +18,6 @@ use Swis\JsonApi\Client\TypeMapper;
 class ItemHydratorTest extends AbstractTest
 {
     /**
-     * @test
-     */
-    public function it_hydrates_items_without_relationships()
-    {
-        $data = [
-            'testattribute1' => 'test',
-            'testattribute2' => 'test2',
-        ];
-
-        $item = new Item();
-
-        $item = $this->getItemHydrator()->hydrate($item, $data);
-
-        $this->assertEquals($data, $item->getAttributes());
-    }
-
-    /**
      * @return \Swis\JsonApi\Client\ItemHydrator
      */
     private function getItemHydrator()
@@ -51,11 +34,25 @@ class ItemHydratorTest extends AbstractTest
     /**
      * @test
      */
-    public function it_hydrates_items_with_hasone_relationships()
+    public function it_hydrates_attributes()
     {
         $data = [
-            'testattribute1'  => 'test',
-            'testattribute2'  => 'test2',
+            'testattribute1' => 'test',
+            'testattribute2' => 'test2',
+        ];
+
+        $item = new Item();
+        $item = $this->getItemHydrator()->hydrate($item, $data);
+
+        $this->assertEquals($data, $item->getAttributes());
+    }
+
+    /**
+     * @test
+     */
+    public function it_hydrates_hasone_relationships_by_id()
+    {
+        $data = [
             'hasone_relation' => 1,
         ];
 
@@ -64,28 +61,78 @@ class ItemHydratorTest extends AbstractTest
 
         /** @var \Swis\JsonApi\Client\Relations\HasOneRelation $hasOne */
         $hasOne = $item->getRelationship('hasone_relation');
+        $this->assertInstanceOf(HasOneRelation::class, $hasOne);
 
-        $this->assertInstanceOf(
-            HasOneRelation::class,
-            $hasOne
-        );
+        $this->assertEquals($data['hasone_relation'], $hasOne->getIncluded()->getId());
+        $this->assertEquals('related-item', $hasOne->getIncluded()->getType());
 
-        $this->assertEquals($data['testattribute1'], $item->getAttribute('testattribute1'));
-        $this->assertEquals($data['testattribute2'], $item->getAttribute('testattribute2'));
-
-        $this->assertEquals($data['hasone_relation'], $hasOne->getId());
-        $this->assertEquals('related-item', $hasOne->getType());
         $this->assertArrayHasKey('hasone_relation', $item->toJsonApiArray()['relationships']);
     }
 
     /**
      * @test
      */
-    public function it_hydrates_items_with_hasmany_relationships()
+    public function it_hydrates_hasone_relationships_with_attributes()
     {
         $data = [
-            'testattribute1'   => 'test',
-            'testattribute2'   => 'test2',
+            'hasone_relation' => [
+                'id'                      => 1,
+                'test_related_attribute1' => 'test',
+                'test_related_attribute2' => 'test2',
+            ],
+        ];
+
+        $item = new WithRelationshipItem();
+        $item = $this->getItemHydrator()->hydrate($item, $data);
+
+        /** @var \Swis\JsonApi\Client\Relations\HasOneRelation $hasOne */
+        $hasOne = $item->getRelationship('hasone_relation');
+        $this->assertInstanceOf(HasOneRelation::class, $hasOne);
+
+        $this->assertEquals($data['hasone_relation']['id'], $hasOne->getIncluded()->getId());
+        $this->assertEquals('related-item', $hasOne->getIncluded()->getType());
+        $this->assertEquals($data['hasone_relation']['test_related_attribute1'], $hasOne->getIncluded()->getAttribute('test_related_attribute1'));
+        $this->assertEquals($data['hasone_relation']['test_related_attribute2'], $hasOne->getIncluded()->getAttribute('test_related_attribute2'));
+
+        $this->assertArrayHasKey('hasone_relation', $item->toJsonApiArray()['relationships']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_hydrates_hasmany_relationships_by_id()
+    {
+        $data = [
+            'hasmany_relation' => [
+                1,
+                2,
+            ],
+        ];
+
+        $item = new WithRelationshipItem();
+        $item = $this->getItemHydrator()->hydrate($item, $data);
+
+        /** @var \Swis\JsonApi\Client\Relations\HasManyRelation $hasMany */
+        $hasMany = $item->getRelationship('hasmany_relation');
+        $this->assertInstanceOf(HasManyRelation::class, $hasMany);
+
+        $this->assertInstanceOf(Collection::class, $hasMany->getIncluded());
+        $this->assertCount(2, $hasMany->getIncluded());
+
+        $this->assertEquals($data['hasmany_relation'][0], $hasMany->getIncluded()->get(0)->getId());
+        $this->assertEquals('related-item', $hasMany->getIncluded()->get(0)->getType());
+        $this->assertEquals($data['hasmany_relation'][1], $hasMany->getIncluded()->get(1)->getId());
+        $this->assertEquals('related-item', $hasMany->getIncluded()->get(1)->getType());
+
+        $this->assertArrayHasKey('hasmany_relation', $item->toJsonApiArray()['relationships']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_hydrates_hasmany_relationships_with_attributes()
+    {
+        $data = [
             'hasmany_relation' => [
                 [
                     'id'                      => 1,
@@ -101,70 +148,59 @@ class ItemHydratorTest extends AbstractTest
         ];
 
         $item = new WithRelationshipItem();
-
         $item = $this->getItemHydrator()->hydrate($item, $data);
+
         /** @var \Swis\JsonApi\Client\Relations\HasManyRelation $hasMany */
         $hasMany = $item->getRelationship('hasmany_relation');
-
-        $this->assertInstanceOf(
-            HasManyRelation::class,
-            $hasMany
-        );
+        $this->assertInstanceOf(HasManyRelation::class, $hasMany);
 
         $this->assertInstanceOf(Collection::class, $hasMany->getIncluded());
         $this->assertCount(2, $hasMany->getIncluded());
 
-        $expected = [
-            [
-                'id'         => 1,
-                'type'       => 'related-item',
-                'attributes' => [
-                    'test_related_attribute1' => 'test',
-                    'test_related_attribute2' => 'test2',
-                ],
-            ],
-            [
-                'id'         => 2,
-                'type'       => 'related-item',
-                'attributes' => [
-                    'test_related_attribute1' => 'test',
-                    'test_related_attribute2' => 'test2',
-                ],
-            ],
-        ];
+        $this->assertEquals($data['hasmany_relation'][0]['id'], $hasMany->getIncluded()->get(0)->getId());
+        $this->assertEquals('related-item', $hasMany->getIncluded()->get(0)->getType());
+        $this->assertEquals($data['hasmany_relation'][0]['test_related_attribute1'], $hasMany->getIncluded()->get(0)->getAttribute('test_related_attribute1'));
+        $this->assertEquals($data['hasmany_relation'][0]['test_related_attribute2'], $hasMany->getIncluded()->get(0)->getAttribute('test_related_attribute2'));
+        $this->assertEquals($data['hasmany_relation'][1]['id'], $hasMany->getIncluded()->get(1)->getId());
+        $this->assertEquals('related-item', $hasMany->getIncluded()->get(1)->getType());
+        $this->assertEquals($data['hasmany_relation'][1]['test_related_attribute1'], $hasMany->getIncluded()->get(1)->getAttribute('test_related_attribute1'));
+        $this->assertEquals($data['hasmany_relation'][1]['test_related_attribute2'], $hasMany->getIncluded()->get(1)->getAttribute('test_related_attribute2'));
 
-        $this->assertEquals($expected, $hasMany->getIncluded()->toJsonApiArray());
         $this->assertArrayHasKey('hasmany_relation', $item->toJsonApiArray()['relationships']);
     }
 
     /**
      * @test
      */
-    public function it_throws_exception_when_morphto_relationship_without_type_attribute()
+    public function it_hydrates_morphto_relationships_by_id()
     {
         $data = [
-            'testattribute1'   => 'test',
-            'testattribute2'   => 'test2',
             'morphto_relation' => [
-                'id'                      => 1,
-                'test_related_attribute1' => 'test',
+                'id'   => 1,
+                'type' => 'related-item',
             ],
         ];
 
         $item = new WithRelationshipItem();
+        $item = $this->getItemHydrator()->hydrate($item, $data);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->getItemHydrator()->hydrate($item, $data);
+        /** @var \Swis\JsonApi\Client\Relations\MorphToRelation $morphTo */
+        $morphTo = $item->getRelationship('morphto_relation');
+        $this->assertInstanceOf(MorphToRelation::class, $morphTo);
+
+        $this->assertEquals($data['morphto_relation']['id'], $morphTo->getIncluded()->getId());
+        $this->assertEquals($data['morphto_relation']['type'], $morphTo->getIncluded()->getType());
+        $this->assertArrayNotHasKey('type', $morphTo->getIncluded()->getAttributes());
+
+        $this->assertArrayHasKey('morphto_relation', $item->toJsonApiArray()['relationships']);
     }
 
     /**
      * @test
      */
-    public function it_hydrates_items_with_morphto_relationship()
+    public function it_hydrates_morphto_relationships_with_attributes()
     {
         $data = [
-            'testattribute1'   => 'test',
-            'testattribute2'   => 'test2',
             'morphto_relation' => [
                 'id'                      => 1,
                 'type'                    => 'related-item',
@@ -177,32 +213,25 @@ class ItemHydratorTest extends AbstractTest
 
         /** @var \Swis\JsonApi\Client\Relations\MorphToRelation $morphTo */
         $morphTo = $item->getRelationship('morphto_relation');
+        $this->assertInstanceOf(MorphToRelation::class, $morphTo);
 
-        $this->assertInstanceOf(
-            MorphToRelation::class,
-            $morphTo
-        );
-        $this->assertEquals($data['testattribute1'], $item->getAttribute('testattribute1'));
-        $this->assertEquals($data['testattribute2'], $item->getAttribute('testattribute2'));
-        $this->assertEquals('related-item', $morphTo->getType());
-        $this->assertEquals('related-item', $morphTo->getIncluded()->getType());
-        $this->assertEquals(
-            $data['morphto_relation']['test_related_attribute1'],
-            $morphTo->getIncluded()->getAttribute('test_related_attribute1')
-        );
+        $this->assertEquals($data['morphto_relation']['id'], $morphTo->getIncluded()->getId());
+        $this->assertEquals($data['morphto_relation']['type'], $morphTo->getIncluded()->getType());
+        $this->assertArrayNotHasKey('type', $morphTo->getIncluded()->getAttributes());
+        $this->assertEquals($data['morphto_relation']['test_related_attribute1'], $morphTo->getIncluded()->getAttribute('test_related_attribute1'));
+
         $this->assertArrayHasKey('morphto_relation', $item->toJsonApiArray()['relationships']);
     }
 
     /**
      * @test
      */
-    public function it_hydrates_unmapped_items_with_morphto_relationship()
+    public function it_hydrates_morphto_relationships_with_unmapped_items()
     {
         $data = [
             'morphto_relation' => [
-                'id'                      => 1,
-                'type'                    => 'unmapped-item',
-                'test_related_attribute1' => 'test',
+                'id'   => 1,
+                'type' => 'unmapped-item',
             ],
         ];
 
@@ -211,25 +240,22 @@ class ItemHydratorTest extends AbstractTest
 
         /** @var \Swis\JsonApi\Client\Relations\MorphToRelation $morphTo */
         $morphTo = $item->getRelationship('morphto_relation');
+        $this->assertInstanceOf(MorphToRelation::class, $morphTo);
 
-        $this->assertEquals('unmapped-item', $morphTo->getType());
-        $this->assertEquals('unmapped-item', $morphTo->getIncluded()->getType());
+        $this->assertEquals($data['morphto_relation']['id'], $morphTo->getIncluded()->getId());
+        $this->assertEquals($data['morphto_relation']['type'], $morphTo->getIncluded()->getType());
         $this->assertArrayNotHasKey('type', $morphTo->getIncluded()->getAttributes());
     }
 
     /**
      * @test
      */
-    public function it_throws_exception_when_morphtomany_relationship_without_type_attribute()
+    public function it_throws_for_morphto_relationships_without_type_attribute()
     {
         $data = [
-            'testattribute1'       => 'test',
-            'testattribute2'       => 'test2',
-            'morphtomany_relation' => [
-                [
-                    'id'                      => 1,
-                    'test_related_attribute1' => 'test',
-                ],
+            'morphto_relation' => [
+                'id'                      => 1,
+                'test_related_attribute1' => 'test',
             ],
         ];
 
@@ -242,11 +268,47 @@ class ItemHydratorTest extends AbstractTest
     /**
      * @test
      */
-    public function it_hydrates_items_with_morphtomany_relationship()
+    public function it_hydrates_morphtomany_relationships_by_id()
     {
         $data = [
-            'testattribute1'       => 'test',
-            'testattribute2'       => 'test2',
+            'morphtomany_relation' => [
+                [
+                    'id'   => 1,
+                    'type' => 'related-item',
+                ],
+                [
+                    'id'   => 2,
+                    'type' => 'another-related-item',
+                ],
+            ],
+        ];
+
+        $item = new WithRelationshipItem();
+        $item = $this->getItemHydrator()->hydrate($item, $data);
+
+        /** @var \Swis\JsonApi\Client\Relations\MorphToManyRelation $morphToMany */
+        $morphToMany = $item->getRelationship('morphtomany_relation');
+        $this->assertInstanceOf(MorphToManyRelation::class, $morphToMany);
+
+        $this->assertInstanceOf(Collection::class, $morphToMany->getIncluded());
+        $this->assertCount(2, $morphToMany->getIncluded());
+
+        $this->assertEquals($data['morphtomany_relation'][0]['id'], $morphToMany->getIncluded()->get(0)->getId());
+        $this->assertEquals($data['morphtomany_relation'][0]['type'], $morphToMany->getIncluded()->get(0)->getType());
+        $this->assertArrayNotHasKey('type', $morphToMany->getIncluded()->get(0)->getAttributes());
+        $this->assertEquals($data['morphtomany_relation'][1]['id'], $morphToMany->getIncluded()->get(1)->getId());
+        $this->assertEquals($data['morphtomany_relation'][1]['type'], $morphToMany->getIncluded()->get(1)->getType());
+        $this->assertArrayNotHasKey('type', $morphToMany->getIncluded()->get(1)->getAttributes());
+
+        $this->assertArrayHasKey('morphtomany_relation', $item->toJsonApiArray()['relationships']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_hydrates_morphtomany_relationships_with_attributes()
+    {
+        $data = [
             'morphtomany_relation' => [
                 [
                     'id'                      => 1,
@@ -266,46 +328,37 @@ class ItemHydratorTest extends AbstractTest
 
         /** @var \Swis\JsonApi\Client\Relations\MorphToManyRelation $morphToMany */
         $morphToMany = $item->getRelationship('morphtomany_relation');
+        $this->assertInstanceOf(MorphToManyRelation::class, $morphToMany);
 
-        $this->assertInstanceOf(
-            MorphToManyRelation::class,
-            $morphToMany
-        );
         $this->assertInstanceOf(Collection::class, $morphToMany->getIncluded());
         $this->assertCount(2, $morphToMany->getIncluded());
 
-        $this->assertEquals($data['testattribute1'], $item->getAttribute('testattribute1'));
-        $this->assertEquals($data['testattribute2'], $item->getAttribute('testattribute2'));
+        $this->assertEquals($data['morphtomany_relation'][0]['id'], $morphToMany->getIncluded()->get(0)->getId());
+        $this->assertEquals($data['morphtomany_relation'][0]['type'], $morphToMany->getIncluded()->get(0)->getType());
+        $this->assertArrayNotHasKey('type', $morphToMany->getIncluded()->get(0)->getAttributes());
+        $this->assertEquals($data['morphtomany_relation'][0]['test_related_attribute1'], $morphToMany->getIncluded()[0]->getAttribute('test_related_attribute1'));
+        $this->assertEquals($data['morphtomany_relation'][1]['id'], $morphToMany->getIncluded()->get(1)->getId());
+        $this->assertEquals($data['morphtomany_relation'][1]['type'], $morphToMany->getIncluded()->get(1)->getType());
+        $this->assertArrayNotHasKey('type', $morphToMany->getIncluded()->get(1)->getAttributes());
+        $this->assertEquals($data['morphtomany_relation'][1]['test_related_attribute1'], $morphToMany->getIncluded()[1]->getAttribute('test_related_attribute1'));
 
-        $this->assertEquals('related-item', $morphToMany->getIncluded()[0]->getType());
-        $this->assertEquals('another-related-item', $morphToMany->getIncluded()[1]->getType());
-        $this->assertEquals(
-            $data['morphtomany_relation'][0]['test_related_attribute1'],
-            $morphToMany->getIncluded()[0]->getAttribute('test_related_attribute1')
-        );
-        $this->assertEquals(
-            $data['morphtomany_relation'][1]['test_related_attribute1'],
-            $morphToMany->getIncluded()[1]->getAttribute('test_related_attribute1')
-        );
         $this->assertArrayHasKey('morphtomany_relation', $item->toJsonApiArray()['relationships']);
     }
 
     /**
      * @test
      */
-    public function it_hydrates_unmapped_items_with_morphtomany_relationship()
+    public function it_hydrates_morphtomany_relationships_with_unmapped_items()
     {
         $data = [
             'morphtomany_relation' => [
                 [
-                    'id'                      => 1,
-                    'type'                    => 'unmapped-item',
-                    'test_related_attribute1' => 'test1',
+                    'id'   => 1,
+                    'type' => 'unmapped-item',
                 ],
                 [
-                    'id'                      => 2,
-                    'type'                    => 'unmapped-item',
-                    'test_related_attribute1' => 'test2',
+                    'id'   => 2,
+                    'type' => 'unmapped-item',
                 ],
             ],
         ];
@@ -316,10 +369,35 @@ class ItemHydratorTest extends AbstractTest
         /** @var \Swis\JsonApi\Client\Relations\MorphToManyRelation $morphToMany */
         $morphToMany = $item->getRelationship('morphtomany_relation');
 
-        $this->assertEquals('unmapped-item', $morphToMany->getIncluded()[0]->getType());
-        $this->assertEquals('unmapped-item', $morphToMany->getIncluded()[1]->getType());
-        $this->assertArrayNotHasKey('type', $morphToMany->getIncluded()[0]->getAttributes());
-        $this->assertArrayNotHasKey('type', $morphToMany->getIncluded()[1]->getAttributes());
+        $this->assertInstanceOf(Collection::class, $morphToMany->getIncluded());
+        $this->assertCount(2, $morphToMany->getIncluded());
+
+        $this->assertEquals($data['morphtomany_relation'][0]['id'], $morphToMany->getIncluded()->get(0)->getId());
+        $this->assertEquals($data['morphtomany_relation'][0]['type'], $morphToMany->getIncluded()->get(0)->getType());
+        $this->assertArrayNotHasKey('type', $morphToMany->getIncluded()->get(0)->getAttributes());
+        $this->assertEquals($data['morphtomany_relation'][1]['id'], $morphToMany->getIncluded()->get(1)->getId());
+        $this->assertEquals($data['morphtomany_relation'][1]['type'], $morphToMany->getIncluded()->get(1)->getType());
+        $this->assertArrayNotHasKey('type', $morphToMany->getIncluded()->get(1)->getAttributes());
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_for_morphtomany_relationships_without_type_attribute()
+    {
+        $data = [
+            'morphtomany_relation' => [
+                [
+                    'id'                      => 1,
+                    'test_related_attribute1' => 'test',
+                ],
+            ],
+        ];
+
+        $item = new WithRelationshipItem();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->getItemHydrator()->hydrate($item, $data);
     }
 
     /**
@@ -328,8 +406,6 @@ class ItemHydratorTest extends AbstractTest
     public function it_hydrates_nested_relationship_items()
     {
         $data = [
-            'testattribute1'  => 'test',
-            'testattribute2'  => 'test2',
             'hasone_relation' => [
                 'id'              => 1,
                 'parent_relation' => 5,
@@ -343,60 +419,14 @@ class ItemHydratorTest extends AbstractTest
         $hasOne = $item->getRelationship('hasone_relation');
         $this->assertInstanceOf(HasOneRelation::class, $hasOne);
 
-        $this->assertEquals($data['testattribute1'], $item->getAttribute('testattribute1'));
-        $this->assertEquals($data['testattribute2'], $item->getAttribute('testattribute2'));
+        $this->assertEquals($data['hasone_relation']['id'], $hasOne->getIncluded()->getId());
+        $this->assertEquals('related-item', $hasOne->getIncluded()->getType());
 
-        $this->assertEquals($data['hasone_relation']['id'], $hasOne->getId());
-        $this->assertEquals('related-item', $hasOne->getType());
-
-        /** @var \Swis\JsonApi\Client\Relations\HasOneRelation $hasOne */
+        /** @var \Swis\JsonApi\Client\Relations\HasOneRelation $hasOneParent */
         $hasOneParent = $hasOne->getIncluded()->getRelationship('parent_relation');
         $this->assertInstanceOf(HasOneRelation::class, $hasOneParent);
 
-        $this->assertEquals($data['hasone_relation']['parent_relation'], $hasOneParent->getId());
-        $this->assertEquals('item-with-relationship', $hasOneParent->getType());
-    }
-
-    /**
-     * @test
-     */
-    public function it_hydrates_a_hasmany_relationship_by_id()
-    {
-        $data = [
-            'testattribute1'   => 'test',
-            'testattribute2'   => 'test2',
-            'hasmany_relation' => [
-                1,
-                2,
-            ],
-        ];
-
-        $item = new WithRelationshipItem();
-
-        $item = $this->getItemHydrator()->hydrate($item, $data);
-        /** @var \Swis\JsonApi\Client\Relations\HasManyRelation $hasMany */
-        $hasMany = $item->getRelationship('hasmany_relation');
-
-        $this->assertInstanceOf(
-            HasManyRelation::class,
-            $hasMany
-        );
-
-        $this->assertInstanceOf(Collection::class, $hasMany->getIncluded());
-        $this->assertCount(2, $hasMany->getIncluded());
-
-        $expected = [
-            [
-                'id'         => 1,
-                'type'       => 'related-item',
-            ],
-            [
-                'id'         => 2,
-                'type'       => 'related-item',
-            ],
-        ];
-
-        $this->assertEquals($expected, $hasMany->getIncluded()->toJsonApiArray());
-        $this->assertArrayHasKey('hasmany_relation', $item->toJsonApiArray()['relationships']);
+        $this->assertEquals($data['hasone_relation']['parent_relation'], $hasOneParent->getIncluded()->getId());
+        $this->assertEquals('item-with-relationship', $hasOneParent->getIncluded()->getType());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I changed the `ItemHydrator` to reflect recent changes in serialization of relations. This makes sure the relation is included in the JSON when hydrated by id using the `ItemHydrator`.

## Motivation and context

Fixes #43 

## How has this been tested?

Tested using updated unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
