### PR TITLE
Laravel 5.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: php
 
 matrix:
   include:
-  - php: "7.0"
-    env: LARAVEL_VERSION="5.5.*"
   - php: "7.1"
     env: LARAVEL_VERSION="5.5.*"
   - php: "7.2"
@@ -11,7 +9,9 @@ matrix:
   - php: "7.2"
     env: LARAVEL_VERSION="5.6.*"
   - php: "7.2"
-    env: LARAVEL_VERSION="5.7.*" RUN_CS_FIXER=1
+    env: LARAVEL_VERSION="5.7.*"
+  - php: "7.2"
+    env: LARAVEL_VERSION="5.8.*" RUN_CS_FIXER=1
 
 sudo: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-* Nothing
+### Added
+
+* Added support for Laravel 5.8.
+
+### Changed
+
+* Dropped Laravel <5.5 support.
+* Dropped PHP <7.1 support.
 
 ## [0.16.0] - 2019-03-14
 

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "type": "library",
     "description": "A PHP package for mapping remote {json:api} resources to Eloquent like models and collections.",
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1.3",
         "ext-json": "*",
         "art4/json-api-client": "^0.9.1",
-        "illuminate/support": "5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*",
         "jenssegers/model": "^1.1",
         "php-http/client-implementation": "^1.0",
         "php-http/discovery": "^1.0"
@@ -14,8 +14,8 @@
     "require-dev": {
         "fzaninotto/faker": "^1.6",
         "friendsofphp/php-cs-fixer": "^2.0",
-        "graham-campbell/testbench": "^4.0|^5.1",
-        "phpunit/phpunit": "^6.1|^7.0",
+        "graham-campbell/testbench": "^5.1",
+        "phpunit/phpunit": "^6.1|^7.0|^8.0",
         "php-http/guzzle6-adapter": "^1.1",
         "php-http/mock-client": "^1.1"
     },

--- a/tests/AbstractTest.php
+++ b/tests/AbstractTest.php
@@ -12,7 +12,7 @@ abstract class AbstractTest extends TestCase
      */
     protected $faker;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->faker = Factory::create();
     }

--- a/tests/ItemRelationsTest.php
+++ b/tests/ItemRelationsTest.php
@@ -33,7 +33,7 @@ class ItemRelationsTest extends AbstractTest
 
         $relations = $masterItem->getRelationships();
 
-        $this->assertArraySubset([
+        $this->assertSame([
             'child' => [
                 'data' => [
                     'type' => 'child',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I've added support for Laravel 5.8.

## Motivation and context

Laravel 5.8 is out and about! I had to drop PHP <7.1 and Laravel <5.5 support in order to make it compatible. But since these are both EOL, I think it is appropriate to do so!

closes #49

## How has this been tested?

Tested with existing unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
