### PR TITLE
Explicit type hint and magic methods for id

### DIFF
--- a/src/Interfaces/ItemInterface.php
+++ b/src/Interfaces/ItemInterface.php
@@ -8,9 +8,9 @@ use Swis\JsonApi\Client\Meta;
 interface ItemInterface extends DataInterface
 {
     /**
-     * @return string
+     * @return string|null
      */
-    public function getId();
+    public function getId(): ? string;
 
     /**
      * @return bool
@@ -23,11 +23,11 @@ interface ItemInterface extends DataInterface
     public function isNew(): bool;
 
     /**
-     * @param string $id
+     * @param string|null $id
      *
      * @return static
      */
-    public function setId($id);
+    public function setId(? string $id);
 
     /**
      * @return string

--- a/src/Item.php
+++ b/src/Item.php
@@ -22,7 +22,7 @@ class Item extends Model implements ItemInterface
     use HasType;
 
     /**
-     * @var
+     * @var string|null
      */
     protected $id;
 
@@ -103,19 +103,19 @@ class Item extends Model implements ItemInterface
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getId()
+    public function getId(): ? string
     {
         return $this->id;
     }
 
     /**
-     * @param string $id
+     * @param string|null $id
      *
      * @return static
      */
-    public function setId($id)
+    public function setId(? string $id)
     {
         $this->id = $id;
 

--- a/src/Item.php
+++ b/src/Item.php
@@ -15,6 +15,9 @@ use Swis\JsonApi\Client\Traits\HasLinks;
 use Swis\JsonApi\Client\Traits\HasMeta;
 use Swis\JsonApi\Client\Traits\HasType;
 
+/**
+ * @property string|null id
+ */
 class Item extends Model implements ItemInterface
 {
     use HasLinks;
@@ -222,6 +225,20 @@ class Item extends Model implements ItemInterface
     /**
      * @param string $key
      *
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        if ($key === 'id') {
+            return $this->getId();
+        }
+
+        return parent::__get($key);
+    }
+
+    /**
+     * @param string $key
+     *
      * @return \Swis\JsonApi\Client\Interfaces\DataInterface|mixed
      */
     public function getAttribute($key)
@@ -241,6 +258,21 @@ class Item extends Model implements ItemInterface
     public function hasAttribute($key): bool
     {
         return array_key_exists($key, $this->attributes);
+    }
+
+    /**
+     * @param string $key
+     * @param mixed  $value
+     */
+    public function __set($key, $value)
+    {
+        if ($key === 'id') {
+            $this->setId($value);
+
+            return;
+        }
+
+        parent::__set($key, $value);
     }
 
     /**
@@ -277,6 +309,10 @@ class Item extends Model implements ItemInterface
      */
     public function __isset($key)
     {
+        if ($key === 'id') {
+            return $this->hasId();
+        }
+
         return parent::__isset($key) || $this->hasRelationship($key) || $this->hasRelationship(snake_case($key));
     }
 

--- a/tests/ItemRelationsTest.php
+++ b/tests/ItemRelationsTest.php
@@ -37,7 +37,7 @@ class ItemRelationsTest extends AbstractTest
             'child' => [
                 'data' => [
                     'type' => 'child',
-                    'id'   => 1,
+                    'id'   => '1',
                 ],
             ],
         ], $relations);

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -14,17 +14,7 @@ use Swis\JsonApi\Client\Tests\Mocks\Items\WithRelationshipItem;
 
 class ItemTest extends AbstractTest
 {
-    protected $attributes;
-
-    /**
-     * ItemTest constructor.
-     */
-    public function __construct()
-    {
-        $this->attributes = ['testKey' => 'testValue'];
-
-        parent::__construct();
-    }
+    protected $attributes = ['testKey' => 'testValue'];
 
     /**
      * @test

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -106,6 +106,40 @@ class ItemTest extends AbstractTest
     /**
      * @test
      */
+    public function it_can_set_the_id_using_the_magic_method()
+    {
+        $item = new Item();
+
+        $item->id = 1234;
+        $this->assertEquals(1234, $item->getId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_get_the_id_using_the_magic_method()
+    {
+        $item = new Item();
+        $item->setId(1234);
+
+        $this->assertEquals(1234, $item->id);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_check_if_the_id_is_set_using_the_magic_method()
+    {
+        $item = new Item();
+
+        $this->assertFalse(isset($item->id));
+        $item->setId(1234);
+        $this->assertTrue(isset($item->id));
+    }
+
+    /**
+     * @test
+     */
     public function it_returns_attributes()
     {
         $item = new Item($this->attributes);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I have added explicit (optional string) type hints to the `setId` and `getId` methods. This requires a change to the interface and can be breaking if you implement the interface yourself. Besides that, I have made the id accessible using magic methods.

## Motivation and context

According to the specification (https://jsonapi.org/format/#document-resource-object-identification), the id must always be a string when present. Making the id accessible via magic methods allows you to set/get the id just like any other attribute. This is useful for example if you want to pluck all ids of a collection of items.

## How has this been tested?

Tested with new unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
