### PR TITLE
Change Repository::save to accept an Item instead of an ItemDocument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-* Nothing
+### Changed
+
+* Change signature of `RepositoryInterface::save()`. It should now receive an `ItemInterface` instead of a `ItemDocumentInterface`.
 
 ## [0.19.0] - 2019-07-10
 

--- a/README.MD
+++ b/README.MD
@@ -253,13 +253,6 @@ $repository->all(['include' => 'author', 'page' => ['limit' => 15, 'offset' => 0
 ```
 
 
-## DocumentFactory
-
-The `Repository` and `DocumentClient` both require `ItemDocumentInterface` instances when creating or updating resources.
-Such documents can easily be created using the `DocumentFactory` by giving it a `DataInterface` instance.
-This can be an `ItemInterface`, usually created by the [ItemHydrator](#itemhydrator), or a `Collection`.
-
-
 ## ItemHydrator
 
 The `ItemHydrator` can be used to fill/hydrate an item and its relations using an associative array with attributes.
@@ -267,15 +260,15 @@ This is useful if you would like to hydrate an item with POST data from your req
 
 ``` php
 $typeMapper = app(Swis\JsonApi\Client\TypeMapper::class);
-$itemDocumentBuilder = app(Swis\JsonApi\Client\ItemDocumentBuilder::class);
+$itemHydrator = app(Swis\JsonApi\Client\ItemHydrator::class);
 $blogRepository = app(App\Repositiories\BlogRepository::class);
 
-$itemDocument = $itemDocumentBuilder->build(
+$item = $itemHydrator->hydrate(
     $typeMapper->getMapping('blog'),
     request()->all(['title', 'author', 'date', 'content', 'tags']),
     request()->id
 );
-$blogRepository->save($itemDocument);
+$blogRepository->save($item);
 ```
 
 ### Relations
@@ -300,7 +293,7 @@ $attributes = [
         56,
     ],
 ];
-$itemDocument = $itemDocumentBuilder->build($typeMapper->getMapping('blog'), $attributes);
+$itemDocument = $itemHydrator->hydrate($typeMapper->getMapping('blog'), $attributes);
 
 echo json_encode($itemDocument, JSON_PRETTY_PRINT);
 
@@ -374,6 +367,13 @@ The `DocumentClient` follows the following steps internally:
 This client is a more low level client and can be used, for example, for posting binary data such as images.
 It can take everything your request factory takes as input data and returns the 'raw' `\Psr\Http\Message\ResponseInterface`.
 It does not parse or validate the response or hydrate items!
+
+
+## DocumentFactory
+
+The `DocumentClient` requires `ItemDocumentInterface` instances when creating or updating resources.
+Such documents can easily be created using the `DocumentFactory` by giving it a `DataInterface` instance.
+This can be an `ItemInterface`, usually created by the [ItemHydrator](#itemhydrator), or a `Collection`.
 
 
 ## Service Provider

--- a/src/Interfaces/RepositoryInterface.php
+++ b/src/Interfaces/RepositoryInterface.php
@@ -17,11 +17,11 @@ interface RepositoryInterface
     public function find(string $id);
 
     /**
-     * @param \Swis\JsonApi\Client\Interfaces\ItemDocumentInterface $document
+     * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $item
      *
      * @return \Swis\JsonApi\Client\Interfaces\ItemDocumentInterface
      */
-    public function save(ItemDocumentInterface $document);
+    public function save(ItemInterface $item);
 
     /**
      * @param string $id

--- a/tests/RepositoryTest.php
+++ b/tests/RepositoryTest.php
@@ -4,6 +4,7 @@ namespace Swis\JsonApi\Client\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Swis\JsonApi\Client\Document;
+use Swis\JsonApi\Client\DocumentFactory;
 use Swis\JsonApi\Client\Interfaces\DocumentClientInterface;
 use Swis\JsonApi\Client\Item;
 use Swis\JsonApi\Client\ItemDocument;
@@ -18,7 +19,7 @@ class RepositoryTest extends TestCase
     {
         /** @var \PHPUnit\Framework\MockObject\MockObject|\Swis\JsonApi\Client\Interfaces\DocumentClientInterface $client */
         $client = $this->getMockBuilder(DocumentClientInterface::class)->getMock();
-        $repository = new MockRepository($client);
+        $repository = new MockRepository($client, new DocumentFactory());
 
         $this->assertSame($client, $repository->getClient());
     }
@@ -30,7 +31,7 @@ class RepositoryTest extends TestCase
     {
         /** @var \PHPUnit\Framework\MockObject\MockObject|\Swis\JsonApi\Client\Interfaces\DocumentClientInterface $client */
         $client = $this->getMockBuilder(DocumentClientInterface::class)->getMock();
-        $repository = new MockRepository($client);
+        $repository = new MockRepository($client, new DocumentFactory());
 
         $this->assertSame('mocks', $repository->getEndpoint());
     }
@@ -50,7 +51,7 @@ class RepositoryTest extends TestCase
             ->with('mocks?foo=bar')
             ->willReturn($document);
 
-        $repository = new MockRepository($client);
+        $repository = new MockRepository($client, new DocumentFactory());
 
         $this->assertSame($document, $repository->all(['foo' => 'bar']));
     }
@@ -70,7 +71,7 @@ class RepositoryTest extends TestCase
             ->with('mocks?foo=bar')
             ->willReturn($document);
 
-        $repository = new MockRepository($client);
+        $repository = new MockRepository($client, new DocumentFactory());
 
         $this->assertSame($document, $repository->take(['foo' => 'bar']));
     }
@@ -90,7 +91,7 @@ class RepositoryTest extends TestCase
             ->with('mocks/1?foo=bar')
             ->willReturn($document);
 
-        $repository = new MockRepository($client);
+        $repository = new MockRepository($client, new DocumentFactory());
 
         $this->assertSame($document, $repository->find(1, ['foo' => 'bar']));
     }
@@ -111,9 +112,9 @@ class RepositoryTest extends TestCase
             ->with('mocks?foo=bar')
             ->willReturn($document);
 
-        $repository = new MockRepository($client);
+        $repository = new MockRepository($client, new DocumentFactory());
 
-        $this->assertSame($document, $repository->save($document, ['foo' => 'bar']));
+        $this->assertSame($document, $repository->save(new Item(), ['foo' => 'bar']));
     }
 
     /**
@@ -132,9 +133,9 @@ class RepositoryTest extends TestCase
             ->with('mocks/1?foo=bar')
             ->willReturn($document);
 
-        $repository = new MockRepository($client);
+        $repository = new MockRepository($client, new DocumentFactory());
 
-        $this->assertSame($document, $repository->save($document, ['foo' => 'bar']));
+        $this->assertSame($document, $repository->save((new Item())->setId(1), ['foo' => 'bar']));
     }
 
     /**
@@ -152,7 +153,7 @@ class RepositoryTest extends TestCase
             ->with('mocks/1?foo=bar')
             ->willReturn($document);
 
-        $repository = new MockRepository($client);
+        $repository = new MockRepository($client, new DocumentFactory());
 
         $this->assertSame($document, $repository->delete(1, ['foo' => 'bar']));
     }


### PR DESCRIPTION
## Description

See title.

## Motivation and context

This change is based on feedback on the last ([0.19.0](https://github.com/swisnl/json-api-client/releases/tag/0.19.0)) release. It removes the need to wrap the Item in an ItemDocument before giving it to the Repository. In 99% of the times you simply wrap the Item in an ItemDocument and directly pass it to the Repository. So the Repository can just as well do it for you making the implementing code cleaner. 

## How has this been tested?

Tested using updated unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
