### PR TITLE
Add extra verifications for links

### DIFF
--- a/src/Parsers/DocumentParser.php
+++ b/src/Parsers/DocumentParser.php
@@ -97,7 +97,7 @@ class DocumentParser implements DocumentParserInterface
         $document = $this->getDocument($data);
 
         if (property_exists($data, 'links')) {
-            $document->setLinks($this->linksParser->parse($data->links));
+            $document->setLinks($this->linksParser->parse($data->links, LinksParser::SOURCE_DOCUMENT));
         }
 
         if (property_exists($data, 'errors')) {

--- a/src/Parsers/ErrorParser.php
+++ b/src/Parsers/ErrorParser.php
@@ -59,7 +59,7 @@ class ErrorParser
 
         return new Error(
             property_exists($data, 'id') ? $data->id : null,
-            property_exists($data, 'links') ? $this->linksParser->parse($data->links) : null,
+            property_exists($data, 'links') ? $this->linksParser->parse($data->links, LinksParser::SOURCE_ERROR) : null,
             property_exists($data, 'status') ? $data->status : null,
             property_exists($data, 'code') ? $data->code : null,
             property_exists($data, 'title') ? $data->title : null,

--- a/src/Parsers/ItemParser.php
+++ b/src/Parsers/ItemParser.php
@@ -87,7 +87,7 @@ class ItemParser
         }
 
         if (property_exists($data, 'links')) {
-            $item->setLinks($this->linksParser->parse($data->links));
+            $item->setLinks($this->linksParser->parse($data->links, LinksParser::SOURCE_ITEM));
         }
 
         if (property_exists($data, 'meta')) {
@@ -142,7 +142,7 @@ class ItemParser
 
             $links = null;
             if (property_exists($relationship, 'links')) {
-                $links = $this->linksParser->parse($relationship->links);
+                $links = $this->linksParser->parse($relationship->links, LinksParser::SOURCE_RELATIONSHIP);
             }
 
             $meta = null;

--- a/src/Parsers/LinksParser.php
+++ b/src/Parsers/LinksParser.php
@@ -2,6 +2,7 @@
 
 namespace Swis\JsonApi\Client\Parsers;
 
+use Swis\JsonApi\Client\Collection;
 use Swis\JsonApi\Client\Exceptions\ValidationException;
 use Swis\JsonApi\Client\Link;
 use Swis\JsonApi\Client\Links;
@@ -11,6 +12,11 @@ use Swis\JsonApi\Client\Links;
  */
 class LinksParser
 {
+    private const LINKS_THAT_MAY_NOT_BE_NULL_WHEN_PRESENT = [
+        'self',
+        'related',
+    ];
+
     /**
      * @var \Swis\JsonApi\Client\Parsers\MetaParser
      */
@@ -32,22 +38,28 @@ class LinksParser
     public function parse($data): Links
     {
         return new Links(
-            array_map(
-                function ($link) {
-                    return $this->buildLink($link);
-                },
-                (array)$data
-            )
+            Collection::wrap((array)$data)
+                ->map(
+                    function ($link, $name) {
+                        return $this->buildLink($link, $name);
+                    }
+                )
+                ->toArray()
         );
     }
 
     /**
-     * @param mixed $data
+     * @param mixed  $data
+     * @param string $name
      *
      * @return \Swis\JsonApi\Client\Link
      */
-    private function buildLink($data): ? Link
+    private function buildLink($data, string $name): ? Link
     {
+        if (in_array($name, self::LINKS_THAT_MAY_NOT_BE_NULL_WHEN_PRESENT, true) && !is_string($data) && !is_object($data)) {
+            throw new ValidationException(sprintf('Link "%s" has to be an object or string, "%s" given.', $name, gettype($data)));
+        }
+
         if ($data === null) {
             return null;
         }
@@ -57,10 +69,10 @@ class LinksParser
         }
 
         if (!is_object($data)) {
-            throw new ValidationException(sprintf('Link has to be an object, string or null, "%s" given.', gettype($data)));
+            throw new ValidationException(sprintf('Link "%s" has to be an object, string or null, "%s" given.', $name, gettype($data)));
         }
         if (!property_exists($data, 'href')) {
-            throw new ValidationException('Link must have a "href" attribute.');
+            throw new ValidationException(sprintf('Link "%s" must have a "href" attribute.', $name));
         }
 
         return new Link($data->href, property_exists($data, 'meta') ? $this->metaParser->parse($data->meta) : null);

--- a/src/Parsers/LinksParser.php
+++ b/src/Parsers/LinksParser.php
@@ -12,6 +12,14 @@ use Swis\JsonApi\Client\Links;
  */
 class LinksParser
 {
+    public const SOURCE_DOCUMENT = 'document';
+
+    public const SOURCE_ERROR = 'error';
+
+    public const SOURCE_ITEM = 'item';
+
+    public const SOURCE_RELATIONSHIP = 'relationship';
+
     private const LINKS_THAT_MAY_NOT_BE_NULL_WHEN_PRESENT = [
         'self',
         'related',
@@ -31,12 +39,20 @@ class LinksParser
     }
 
     /**
-     * @param mixed $data
+     * @param mixed  $data
+     * @param string $source
      *
      * @return \Swis\JsonApi\Client\Links
      */
-    public function parse($data): Links
+    public function parse($data, string $source): Links
     {
+        if ($source === self::SOURCE_ERROR && !property_exists($data, 'about')) {
+            throw new ValidationException('Error links object MUST contain at least one of the following properties: `about`.');
+        }
+        if ($source === self::SOURCE_RELATIONSHIP && !property_exists($data, 'self') && !property_exists($data, 'related')) {
+            throw new ValidationException('Relationship links object MUST contain at least one of the following properties: `self`, `related`.');
+        }
+
         return new Links(
             Collection::wrap((array)$data)
                 ->map(

--- a/tests/Parsers/LinksParserTest.php
+++ b/tests/Parsers/LinksParserTest.php
@@ -18,7 +18,7 @@ class LinksParserTest extends AbstractTest
     public function it_converts_data_to_links()
     {
         $parser = new LinksParser(new MetaParser());
-        $links = $parser->parse($this->getLinks());
+        $links = $parser->parse($this->getLinks(), LinksParser::SOURCE_DOCUMENT);
 
         $this->assertInstanceOf(Links::class, $links);
         $this->assertCount(4, $links->toArray());
@@ -59,7 +59,7 @@ class LinksParserTest extends AbstractTest
 
         $this->expectException(ValidationException::class);
 
-        $parser->parse($invalidData);
+        $parser->parse($invalidData, LinksParser::SOURCE_DOCUMENT);
     }
 
     public function provideInvalidData(): array
@@ -81,7 +81,7 @@ class LinksParserTest extends AbstractTest
 
         $this->expectException(ValidationException::class);
 
-        $parser->parse(json_decode('{"self": null}', false));
+        $parser->parse(json_decode('{"self": null}', false), LinksParser::SOURCE_DOCUMENT);
     }
 
     /**
@@ -93,7 +93,31 @@ class LinksParserTest extends AbstractTest
 
         $this->expectException(ValidationException::class);
 
-        $parser->parse(json_decode('{"related": null}', false));
+        $parser->parse(json_decode('{"related": null}', false), LinksParser::SOURCE_DOCUMENT);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_error_links_misses_about_link()
+    {
+        $parser = new LinksParser($this->createMock(MetaParser::class));
+
+        $this->expectException(ValidationException::class);
+
+        $parser->parse(json_decode('{}', false), LinksParser::SOURCE_ERROR);
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_when_relationship_links_misses_self_and_related_links()
+    {
+        $parser = new LinksParser($this->createMock(MetaParser::class));
+
+        $this->expectException(ValidationException::class);
+
+        $parser->parse(json_decode('{}', false), LinksParser::SOURCE_RELATIONSHIP);
     }
 
     /**
@@ -105,7 +129,7 @@ class LinksParserTest extends AbstractTest
 
         $this->expectException(ValidationException::class);
 
-        $parser->parse(json_decode('{"self": {}}', false));
+        $parser->parse(json_decode('{"self": {}}', false), LinksParser::SOURCE_DOCUMENT);
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Self and related links can no longer be `null`.
- Some links objects MUST now have certain links if a links object is present:
Error: about
Relationship: self or related

## Motivation and context

According to the spec, self and related links can not be `null`, only pagination links can be.

Spec for error: https://jsonapi.org/format/#error-objects
Spec for relationship: https://jsonapi.org/format/#document-resource-object-relationships

## How has this been tested?

Tested with new and updated unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
