### PR TITLE
Use PSR-18 (and PSR-17) interfaces instead of PHP-HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+* Switched from [PHP-HTTP](http://php-http.org/) to [PSR-18](https://www.php-fig.org/psr/psr-18/), its successor.
+* The `\Swis\JsonApi\Client\Client` now uses [php-http/discovery](https://github.com/php-http/discovery) itself instead of the service provider. This should make usage without Laravel easier.
+* Removed the `$baseUri` parameter from `\Swis\JsonApi\Client\Client::__construct()`, use `\Swis\JsonApi\Client\Client::setBaseUri()` instead.
+
+### Removed
+
+* Removed `\Swis\JsonApi\Client\Providers\ServiceProvider::getHttpClient()` and `\Swis\JsonApi\Client\Providers\ServiceProvider::getMessageFactory()` as the client now discovers these classes itself. Custom HTTP clients must now be registered within your own service provider using a custom container binding.
+
 ### Fixed
 
 * Self and related links can not be `null` [#59](https://github.com/swisnl/json-api-client/pull/59).

--- a/README.MD
+++ b/README.MD
@@ -19,12 +19,12 @@ A PHP package for mapping remote [JSON:API](http://jsonapi.org/) resources to El
 composer require swisnl/json-api-client
 ```
 
-N.B. Make sure you have installed a HTTP Client before you install this package or install one at the same time e.g. `composer require swisnl/json-api-client php-http/guzzle6-adapter`.
+N.B. Make sure you have installed a PSR-18 HTTP Client before you install this package or install one at the same time e.g. `composer require swisnl/json-api-client php-http/guzzle6-adapter`.
 
 ### HTTP Client
 
-We are decoupled from any HTTP messaging client with the help of [PHP-HTTP](http://docs.php-http.org/en/latest/httplug/users.html).
-This requires another package providing [php-http/client-implementation](https://packagist.org/providers/php-http/client-implementation).
+We are decoupled from any HTTP messaging client with the help of [PSR-18 HTTP Client](https://www.php-fig.org/psr/psr-18/).
+This requires an extra package providing [psr/http-client-implementation](https://packagist.org/providers/psr/http-client-implementation).
 To use Guzzle 6, for example, simply require `php-http/guzzle6-adapter`:
 
 ``` bash
@@ -498,43 +498,37 @@ The service provider registers the `TypeMapper` as a singleton so your entire ap
 ### Bind Clients
 
 The service provider registers the `Client` and `DocumentClient` to your application.
-By default it uses [php-http/discovery](https://github.com/php-http/discovery) to find a HTTP client and message factory.
-You can specify your own message factory by overwriting the `getMessageFactory()` method and your own HTTP client by overwriting the `getHttpClient()` method.
-The first should return a message factory and the latter should return a HTTP client, both implementing HTTPlug.
-These methods are the perfect place to add extra options to your HTTP client or register a mock HTTP client for your tests:
+By default the `Client` uses [php-http/discovery](https://github.com/php-http/discovery) to find an available HTTP client, request factory and stream factory so you don't have to setup those yourself.
+You can specify your own HTTP client, request factory or stream factory by customizing the container binding.
+This is a perfect way to add extra options to your HTTP client or register a mock HTTP client for your tests:
 
 ``` php
-protected function getHttpClient(): HttpClient
+class ServiceProvider extends \Illuminate\Support\ServiceProvider
 {
-    if (app()->environment('testing')) {
-        return new \Swis\Http\Fixture\Client(
-            new \Swis\Http\Fixture\ResponseBuilder('/path/to/fixtures');
-        );
+    protected function register()
+    {
+        $this->app->bind(\Swis\JsonApi\Client\Client::class, function ($app) {
+            if ($app->environment('testing')) {
+                $httpClient = new \Swis\Http\Fixture\Client(
+                    new \Swis\Http\Fixture\ResponseBuilder('/path/to/fixtures');
+                );
+            } else {
+                $httpClient = \Http\Adapter\Guzzle6\Client::createWithConfig(
+                    [
+                        'timeout' => 2,
+                    ]
+                );
+            }
+    
+            return new \Swis\JsonApi\Client\Client($httpClient);
+        });
     }
-
-    return \Http\Adapter\Guzzle6\Client::createWithConfig(
-        [
-            'timeout' => 2,
-        ]
-    );
 }
 ```
 
 N.B. This example uses our [swisnl/php-http-fixture-client](https://github.com/swisnl/php-http-fixture-client) when in testing environment.
 This package allows you to easily mock requests with static fixtures.
 Definitely worth a try!
-
-If you register your own service provider and use package auto discover, don't forget to exclude this package in your `package.json`:
-
-``` json
-"extra": {
-  "laravel": {
-    "dont-discover": [
-      "swisnl/json-api-client"
-    ]
-  }
-},
-```
 
 
 ## Advanced usage

--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,20 @@
         "ext-json": "*",
         "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*",
         "jenssegers/model": "^1.1",
-        "php-http/client-implementation": "^1.0",
-        "php-http/discovery": "^1.0"
+        "nyholm/psr7": "^1.2",
+        "php-http/discovery": "^1.0",
+        "psr/http-client": "^1.0",
+        "psr/http-client-implementation": "^1.0",
+        "psr/http-factory": "^1.0",
+        "psr/http-factory-implementation": "^1.0",
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.0",
         "graham-campbell/testbench": "^5.1",
         "phpunit/phpunit": "^6.1|^7.0|^8.0",
-        "php-http/guzzle6-adapter": "^1.1",
-        "php-http/mock-client": "^1.1"
+        "php-http/guzzle6-adapter": "^2.0",
+        "php-http/mock-client": "^1.2"
     },
     "suggest": {
         "swisnl/php-http-fixture-client": "Allows for easily mocking API calls with fixtures in your tests"

--- a/src/DocumentClient.php
+++ b/src/DocumentClient.php
@@ -42,7 +42,7 @@ class DocumentClient implements DocumentClientInterface
     /**
      * @param string $baseUri
      */
-    public function setBaseUri(string $baseUri)
+    public function setBaseUri(string $baseUri): void
     {
         $this->client->setBaseUri($baseUri);
     }

--- a/src/Interfaces/ClientInterface.php
+++ b/src/Interfaces/ClientInterface.php
@@ -15,18 +15,18 @@ interface ClientInterface
     public function get(string $endpoint, array $headers = []): ResponseInterface;
 
     /**
-     * @param string                                                                         $endpoint
-     * @param resource|string|int|float|bool|\Psr\Http\Message\StreamInterface|callable|null $body
-     * @param array                                                                          $headers
+     * @param string                                                 $endpoint
+     * @param string|resource|\Psr\Http\Message\StreamInterface|null $body
+     * @param array                                                  $headers
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
     public function patch(string $endpoint, $body, array $headers = []): ResponseInterface;
 
     /**
-     * @param string                                                                         $endpoint
-     * @param resource|string|int|float|bool|\Psr\Http\Message\StreamInterface|callable|null $body
-     * @param array                                                                          $headers
+     * @param string                                                 $endpoint
+     * @param string|resource|\Psr\Http\Message\StreamInterface|null $body
+     * @param array                                                  $headers
      *
      * @return \Psr\Http\Message\ResponseInterface
      */

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -2,9 +2,8 @@
 
 namespace Swis\JsonApi\Client\Tests;
 
-use Http\Client\Common\Exception\LoopException;
-use Http\Client\Exception\HttpException;
-use Http\Discovery\MessageFactoryDiscovery;
+use function GuzzleHttp\Psr7\stream_for;
+use Http\Mock\Client as HttpMockClient;
 use Psr\Http\Message\ResponseInterface;
 use Swis\JsonApi\Client\Client;
 
@@ -13,17 +12,11 @@ class ClientTest extends AbstractTest
     /**
      * @test
      */
-    public function the_base_url_can_be_changed_after_instantiation()
+    public function it_can_get_and_set_the_base_url()
     {
-        $httpClient = new \Http\Mock\Client();
+        $client = new Client();
 
-        $client = new Client(
-            $httpClient,
-            'http://www.test.com',
-            MessageFactoryDiscovery::find()
-        );
-
-        $this->assertEquals('http://www.test.com', $client->getBaseUri());
+        $this->assertEquals('', $client->getBaseUri());
         $client->setBaseUri('http://www.test-changed.com');
         $this->assertEquals('http://www.test-changed.com', $client->getBaseUri());
     }
@@ -31,15 +24,9 @@ class ClientTest extends AbstractTest
     /**
      * @test
      */
-    public function the_default_headers_can_be_changed_after_instantiation()
+    public function it_can_get_and_set_the_default_headers()
     {
-        $httpClient = new \Http\Mock\Client();
-
-        $client = new Client(
-            $httpClient,
-            'http://www.test.com',
-            MessageFactoryDiscovery::find()
-        );
+        $client = new Client();
 
         $this->assertEquals(
             [
@@ -70,26 +57,20 @@ class ClientTest extends AbstractTest
      */
     public function it_builds_a_get_request()
     {
-        $baseUri = 'http://www.test.com';
+        $httpClient = new HttpMockClient();
+        $client = new Client($httpClient);
+
         $endpoint = '/test/1';
 
-        $httpClient = new \Http\Mock\Client();
-
-        $client = new Client(
-            $httpClient,
-            $baseUri,
-            MessageFactoryDiscovery::find()
-        );
         $response = $client->get($endpoint, ['X-Foo' => 'bar']);
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals('GET', $httpClient->getLastRequest()->getMethod());
-        $this->assertEquals($baseUri.$endpoint, $httpClient->getLastRequest()->getUri());
+        $this->assertEquals($endpoint, $httpClient->getLastRequest()->getUri());
         $this->assertEquals(
             [
                 'Accept'       => ['application/vnd.api+json'],
                 'Content-Type' => ['application/vnd.api+json'],
                 'X-Foo'        => ['bar'],
-                'Host'         => ['www.test.com'],
             ],
             $httpClient->getLastRequest()->getHeaders()
         );
@@ -100,26 +81,20 @@ class ClientTest extends AbstractTest
      */
     public function it_builds_a_delete_request()
     {
-        $baseUri = 'http://www.test.com';
+        $httpClient = new HttpMockClient();
+        $client = new Client($httpClient);
+
         $endpoint = '/test/1';
 
-        $httpClient = new \Http\Mock\Client();
-
-        $client = new Client(
-            $httpClient,
-            $baseUri,
-            MessageFactoryDiscovery::find()
-        );
         $response = $client->delete($endpoint, ['X-Foo' => 'bar']);
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals('DELETE', $httpClient->getLastRequest()->getMethod());
-        $this->assertEquals($baseUri.$endpoint, $httpClient->getLastRequest()->getUri());
+        $this->assertEquals($endpoint, $httpClient->getLastRequest()->getUri());
         $this->assertEquals(
             [
                 'Accept'       => ['application/vnd.api+json'],
                 'Content-Type' => ['application/vnd.api+json'],
                 'X-Foo'        => ['bar'],
-                'Host'         => ['www.test.com'],
             ],
             $httpClient->getLastRequest()->getHeaders()
         );
@@ -130,27 +105,21 @@ class ClientTest extends AbstractTest
      */
     public function it_builds_a_patch_request()
     {
-        $baseUri = 'http://www.test.com';
+        $httpClient = new HttpMockClient();
+        $client = new Client($httpClient);
+
         $endpoint = '/test/1';
 
-        $httpClient = new \Http\Mock\Client();
-
-        $client = new Client(
-            $httpClient,
-            $baseUri,
-            MessageFactoryDiscovery::find()
-        );
         $response = $client->patch($endpoint, 'testvar=testvalue', ['Content-Type' => 'application/pdf', 'X-Foo' => 'bar']);
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals('PATCH', $httpClient->getLastRequest()->getMethod());
-        $this->assertEquals('testvar=testvalue', $httpClient->getLastRequest()->getBody()->getContents());
-        $this->assertEquals($baseUri.$endpoint, $httpClient->getLastRequest()->getUri());
+        $this->assertEquals('testvar=testvalue', (string)$httpClient->getLastRequest()->getBody());
+        $this->assertEquals($endpoint, $httpClient->getLastRequest()->getUri());
         $this->assertEquals(
             [
                 'Accept'       => ['application/vnd.api+json'],
                 'Content-Type' => ['application/pdf'],
                 'X-Foo'        => ['bar'],
-                'Host'         => ['www.test.com'],
             ],
             $httpClient->getLastRequest()->getHeaders()
         );
@@ -161,27 +130,21 @@ class ClientTest extends AbstractTest
      */
     public function it_builds_a_post_request()
     {
-        $baseUri = 'http://www.test.com';
+        $httpClient = new HttpMockClient();
+        $client = new Client($httpClient);
+
         $endpoint = '/test/1';
 
-        $httpClient = new \Http\Mock\Client();
-
-        $client = new Client(
-            $httpClient,
-            $baseUri,
-            MessageFactoryDiscovery::find()
-        );
         $response = $client->post($endpoint, 'testvar=testvalue', ['Content-Type' => 'application/pdf', 'X-Foo' => 'bar']);
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals('POST', $httpClient->getLastRequest()->getMethod());
-        $this->assertEquals('testvar=testvalue', $httpClient->getLastRequest()->getBody()->getContents());
-        $this->assertEquals($baseUri.$endpoint, $httpClient->getLastRequest()->getUri());
+        $this->assertEquals('testvar=testvalue', (string)$httpClient->getLastRequest()->getBody());
+        $this->assertEquals($endpoint, $httpClient->getLastRequest()->getUri());
         $this->assertEquals(
             [
                 'Accept'       => ['application/vnd.api+json'],
                 'Content-Type' => ['application/pdf'],
                 'X-Foo'        => ['bar'],
-                'Host'         => ['www.test.com'],
             ],
             $httpClient->getLastRequest()->getHeaders()
         );
@@ -192,26 +155,20 @@ class ClientTest extends AbstractTest
      */
     public function it_builds_other_requests()
     {
-        $baseUri = 'http://www.test.com';
+        $httpClient = new HttpMockClient();
+        $client = new Client($httpClient);
+
         $endpoint = '/test/1';
 
-        $httpClient = new \Http\Mock\Client();
-
-        $client = new Client(
-            $httpClient,
-            $baseUri,
-            MessageFactoryDiscovery::find()
-        );
         $response = $client->request('OPTIONS', $endpoint, null, ['Content-Type' => 'application/pdf', 'X-Foo' => 'bar']);
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals('OPTIONS', $httpClient->getLastRequest()->getMethod());
-        $this->assertEquals($baseUri.$endpoint, $httpClient->getLastRequest()->getUri());
+        $this->assertEquals($endpoint, $httpClient->getLastRequest()->getUri());
         $this->assertEquals(
             [
                 'Accept'       => ['application/vnd.api+json'],
                 'Content-Type' => ['application/pdf'],
                 'X-Foo'        => ['bar'],
-                'Host'         => ['www.test.com'],
             ],
             $httpClient->getLastRequest()->getHeaders()
         );
@@ -220,53 +177,61 @@ class ClientTest extends AbstractTest
     /**
      * @test
      */
-    public function it_passes_http_exceptions()
+    public function it_builds_requests_with_a_string_as_body()
     {
-        $baseUri = 'http://www.test.com';
-        $endpoint = '/test/1';
+        $httpClient = new HttpMockClient();
+        $client = new Client($httpClient);
 
-        $httpClient = new \Http\Mock\Client();
+        $body = 'testvar=testvalue';
 
-        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
-        $response = $this->createMock(\Psr\Http\Message\ResponseInterface::class);
-
-        $exception = HttpException::create($request, $response);
-        $httpClient->setDefaultException($exception);
-
-        $client = new Client(
-            $httpClient,
-            $baseUri,
-            MessageFactoryDiscovery::find()
-        );
-
-        $httpResponse = $client->get($endpoint);
-
-        $this->assertSame($response, $httpResponse);
+        $response = $client->request('POST', '/test/1', $body);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals('testvar=testvalue', (string)$httpClient->getLastRequest()->getBody());
     }
 
     /**
      * @test
      */
-    public function it_throws_non_http_exceptions()
+    public function it_builds_requests_with_a_resource_as_body()
     {
-        $baseUri = 'http://www.test.com';
-        $endpoint = '/test/1';
+        $httpClient = new HttpMockClient();
+        $client = new Client($httpClient);
 
-        $httpClient = new \Http\Mock\Client();
+        $body = fopen('php://temp', 'r+');
+        fwrite($body, 'testvar=testvalue');
 
-        $request = $this->createMock(\Psr\Http\Message\RequestInterface::class);
+        $response = $client->request('POST', '/test/1', $body);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals('testvar=testvalue', (string)$httpClient->getLastRequest()->getBody());
+    }
 
-        $exception = new LoopException('Whoops, detected a loop!', $request);
-        $httpClient->setDefaultException($exception);
+    /**
+     * @test
+     */
+    public function it_builds_requests_with_a_stream_as_body()
+    {
+        $httpClient = new HttpMockClient();
+        $client = new Client($httpClient);
 
-        $client = new Client(
-            $httpClient,
-            $baseUri,
-            MessageFactoryDiscovery::find()
-        );
+        $body = stream_for('testvar=testvalue');
 
-        $this->expectException(LoopException::class);
+        $response = $client->request('POST', '/test/1', $body);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals('testvar=testvalue', (string)$httpClient->getLastRequest()->getBody());
+    }
 
-        $client->get($endpoint);
+    /**
+     * @test
+     */
+    public function it_builds_requests_without_a_body()
+    {
+        $httpClient = new HttpMockClient();
+        $client = new Client($httpClient);
+
+        $body = null;
+
+        $response = $client->request('POST', '/test/1', $body);
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertEquals('', (string)$httpClient->getLastRequest()->getBody());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I updated the client so it requires a PSR-18 HTTP client instead of a PHP-HTTP client. As this is a breaking change, I took the liberty to also change the way our client is bound in the service provider. The client now discovers HTTP clients itself. A custom HTTP client must now be registered by customizing the container binding.

## Motivation and context

PSR-18 has been released for a while and most PHP-HTTP implementations now also implement PSR-18. Both changes should also make the usage without Laravel easier.

I also implemented PSR-17 HTTP factories as the currently used factory in combination with the discovery is deprecated. Currently just a few libraries implement these interfaces, so I required [nyholm/psr7](https://github.com/Nyholm/psr7) for now. Once most HTTP clients implement these interfaces (Guzzle for example is working on it), we can drop it as a dependency and leave it to the consumer to choose an implementation.

## How has this been tested?

Tested with existing/updated unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
