### PR TITLE
Fix parsing of empty singular relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-* Nothing
+### Fixed
+
+* Fixed parsing of empty singular relationships.
 
 ## [1.0.0-beta.2] - 2019-09-20
 

--- a/src/Parsers/DocumentParser.php
+++ b/src/Parsers/DocumentParser.php
@@ -178,8 +178,12 @@ class DocumentParser implements DocumentParserInterface
             function (ItemInterface $item) use ($keyedItems) {
                 foreach ($item->getRelations() as $name => $relation) {
                     if ($relation instanceof OneRelationInterface) {
-                        /** @var \Swis\JsonApi\Client\Interfaces\ItemInterface $relatedItem */
+                        /** @var \Swis\JsonApi\Client\Interfaces\ItemInterface|null $relatedItem */
                         $relatedItem = $relation->getIncluded();
+
+                        if ($relatedItem === null) {
+                            continue;
+                        }
 
                         $includedItem = $this->getItem($keyedItems, $relatedItem);
                         if ($includedItem !== null) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Parsing an empty singular relationship caused a PHP error.

## Motivation and context

Fixes #62 

## How has this been tested?

Tested with new unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
