### PR TITLE
Throw a ValidationException when document contains duplicate resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 * Reworded `ValidationException` messages to align them with the wordings used in the specification.
+* `DocumentParser` throws a `ValidationException` when it encounters duplicate resources.
 
 ## [1.0.0-beta.3] - 2019-09-30
 

--- a/tests/Parsers/DocumentParserTest.php
+++ b/tests/Parsers/DocumentParserTest.php
@@ -183,6 +183,42 @@ class DocumentParserTest extends AbstractTest
     /**
      * @test
      */
+    public function it_throws_when_it_finds_duplicate_resources()
+    {
+        $parser = $this->getDocumentParser();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Resources MUST be unique based on their `type` and `id`, 1 duplicate(s) found.');
+
+        $parser->parse(
+            json_encode(
+                [
+                    'data' => [
+                        [
+                            'type' => 'master',
+                            'id' => '1',
+                            'attributes' => [
+                                'foo' => 'bar',
+                            ],
+                        ],
+                    ],
+                    'included' => [
+                        [
+                            'type' => 'master',
+                            'id' => '1',
+                            'attributes' => [
+                                'foo' => 'bar',
+                            ],
+                        ],
+                    ],
+                ]
+            )
+        );
+    }
+
+    /**
+     * @test
+     */
     public function it_parses_a_resource_document()
     {
         $parser = $this->getDocumentParser();


### PR DESCRIPTION
## Description

The `DocumentParser` now throws a `ValidationException` when a document contains duplicate resources. Earlier we had a workaround for duplicate resources, but that is not allowed according to the spec, so I also removed the workaround.

## Motivation and context

See https://jsonapi.org/format/#document-resource-object-identification

## How has this been tested?

Tested with new unit test.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
