### PR TITLE
Unset relation when null (singular) or empty array (plural)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -372,8 +372,10 @@ $attributes = [
         'name'     => 'Björn Brala',
         'homepage' => 'https://github.com/bbrala',
     ],
+    'co-author' => null,
     'date'    => '2018-12-02 15:26:32',
     'content' => 'JSON:API was originally drafted in May 2013 by Yehuda Katz...',
+    'media' => [],
     'tags'    => [
         1,
         15,
@@ -398,6 +400,12 @@ echo json_encode($itemDocument, JSON_PRETTY_PRINT);
                     "type": "author",
                     "id": "f1a775ef-9407-40ba-93ff-7bd737888dc6"
                 }
+            },
+            "co-author": {
+                "data": null
+            },
+            "media": {
+                "data": []
             },
             "tags": {
                 "data": [{
@@ -426,6 +434,7 @@ echo json_encode($itemDocument, JSON_PRETTY_PRINT);
 
 As you can see in this example, relations can be hydrated by id, or by an associative array with an id and more attributes.
 If the item is hydrated using an associative array, it will be included in the resulting json unless `setOmitIncluded(true)` is called on the relation.
+You can unset a relation by passing `null` for singular relations or an empty array for plural relations.
 
 N.B. Morph relations require a 'type' attribute to be present in the data in order to know which type of item should be created.
 

--- a/src/ItemHydrator.php
+++ b/src/ItemHydrator.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Swis\JsonApi\Client\Exceptions\HydrationException;
 use Swis\JsonApi\Client\Interfaces\ItemInterface;
+use Swis\JsonApi\Client\Interfaces\ManyRelationInterface;
+use Swis\JsonApi\Client\Interfaces\OneRelationInterface;
 use Swis\JsonApi\Client\Interfaces\TypeMapperInterface;
 use Swis\JsonApi\Client\Relations\HasManyRelation;
 use Swis\JsonApi\Client\Relations\HasOneRelation;
@@ -75,6 +77,16 @@ class ItemHydrator
             }
 
             $relation = $this->getRelationFromItem($item, $availableRelation);
+
+            // The relation should be unset
+            if (
+                ($relation instanceof OneRelationInterface && $attributes[$availableRelation] === null) ||
+                ($relation instanceof ManyRelationInterface && $attributes[$availableRelation] === [])
+            ) {
+                $relation->dissociate();
+
+                return;
+            }
 
             // It is a valid relation
             if ($relation instanceof HasOneRelation) {

--- a/tests/ItemHydratorTest.php
+++ b/tests/ItemHydratorTest.php
@@ -105,6 +105,28 @@ class ItemHydratorTest extends AbstractTest
     /**
      * @test
      */
+    public function it_dissociates_hasone_relationships_when_null()
+    {
+        $data = [
+            'hasone_relation' => null,
+        ];
+
+        $item = new WithRelationshipItem();
+        $item = $this->getItemHydrator()->hydrate($item, $data);
+
+        /** @var \Swis\JsonApi\Client\Relations\HasOneRelation $hasOne */
+        $hasOne = $item->getRelation('hasone_relation');
+        $this->assertInstanceOf(HasOneRelation::class, $hasOne);
+
+        $this->assertNull($hasOne->getIncluded());
+
+        $this->assertArrayHasKey('hasone_relation', $item->toJsonApiArray()['relationships']);
+        $this->assertNull($item->toJsonApiArray()['relationships']['hasone_relation']['data']);
+    }
+
+    /**
+     * @test
+     */
     public function it_hydrates_hasmany_relationships_by_id()
     {
         $data = [
@@ -177,6 +199,28 @@ class ItemHydratorTest extends AbstractTest
     /**
      * @test
      */
+    public function it_dissociates_hasmany_relationships_when_empty_array()
+    {
+        $data = [
+            'hasmany_relation' => [],
+        ];
+
+        $item = new WithRelationshipItem();
+        $item = $this->getItemHydrator()->hydrate($item, $data);
+
+        /** @var \Swis\JsonApi\Client\Relations\HasManyRelation $hasMany */
+        $hasMany = $item->getRelation('hasmany_relation');
+        $this->assertInstanceOf(HasManyRelation::class, $hasMany);
+
+        $this->assertTrue($hasMany->getIncluded()->isEmpty());
+
+        $this->assertArrayHasKey('hasmany_relation', $item->toJsonApiArray()['relationships']);
+        $this->assertSame([], $item->toJsonApiArray()['relationships']['hasmany_relation']['data']);
+    }
+
+    /**
+     * @test
+     */
     public function it_hydrates_morphto_relationships_by_id()
     {
         $data = [
@@ -226,6 +270,28 @@ class ItemHydratorTest extends AbstractTest
         $this->assertEquals($data['morphto_relation']['test_related_attribute1'], $morphTo->getIncluded()->getAttribute('test_related_attribute1'));
 
         $this->assertArrayHasKey('morphto_relation', $item->toJsonApiArray()['relationships']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_dissociates_morphto_relationships_when_null()
+    {
+        $data = [
+            'morphto_relation' => null,
+        ];
+
+        $item = new WithRelationshipItem();
+        $item = $this->getItemHydrator()->hydrate($item, $data);
+
+        /** @var \Swis\JsonApi\Client\Relations\MorphToRelation $morphTo */
+        $morphTo = $item->getRelation('morphto_relation');
+        $this->assertInstanceOf(MorphToRelation::class, $morphTo);
+
+        $this->assertNull($morphTo->getIncluded());
+
+        $this->assertArrayHasKey('morphto_relation', $item->toJsonApiArray()['relationships']);
+        $this->assertNull($item->toJsonApiArray()['relationships']['morphto_relation']['data']);
     }
 
     /**
@@ -348,6 +414,28 @@ class ItemHydratorTest extends AbstractTest
         $this->assertEquals($data['morphtomany_relation'][1]['test_related_attribute1'], $morphToMany->getIncluded()[1]->getAttribute('test_related_attribute1'));
 
         $this->assertArrayHasKey('morphtomany_relation', $item->toJsonApiArray()['relationships']);
+    }
+
+    /**
+     * @test
+     */
+    public function it_dissociates_morphtomany_relationships_when_empty_array()
+    {
+        $data = [
+            'morphtomany_relation' => [],
+        ];
+
+        $item = new WithRelationshipItem();
+        $item = $this->getItemHydrator()->hydrate($item, $data);
+
+        /** @var \Swis\JsonApi\Client\Relations\MorphToManyRelation $morphToMany */
+        $morphToMany = $item->getRelation('morphtomany_relation');
+        $this->assertInstanceOf(MorphToManyRelation::class, $morphToMany);
+
+        $this->assertTrue($morphToMany->getIncluded()->isEmpty());
+
+        $this->assertArrayHasKey('morphtomany_relation', $item->toJsonApiArray()['relationships']);
+        $this->assertSame([], $item->toJsonApiArray()['relationships']['morphtomany_relation']['data']);
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

You can now unset a relation using the `ItemHydrator` by passing `null` (singular relation) or `[]` (plural relation).

## Motivation and context

The `ItemHydrator` currently hydrates the relation with an item with id `null` for singular relations or no relation at all for plural relations.

Closes: #66

## How has this been tested?

Tested with new unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
