### PR TITLE
Do not require error links object to contain an about member

### DIFF
--- a/src/Parsers/LinksParser.php
+++ b/src/Parsers/LinksParser.php
@@ -49,9 +49,6 @@ class LinksParser
         if (!is_object($data)) {
             throw new ValidationException(sprintf('Links MUST be an object, "%s" given.', gettype($data)));
         }
-        if ($source === self::SOURCE_ERROR && !property_exists($data, 'about')) {
-            throw new ValidationException('Error links object MUST contain at least one of the following properties: `about`.');
-        }
         if ($source === self::SOURCE_RELATIONSHIP && !property_exists($data, 'self') && !property_exists($data, 'related')) {
             throw new ValidationException('Relationship links object MUST contain at least one of the following properties: `self`, `related`.');
         }

--- a/tests/Parsers/LinksParserTest.php
+++ b/tests/Parsers/LinksParserTest.php
@@ -130,19 +130,6 @@ class LinksParserTest extends AbstractTest
     /**
      * @test
      */
-    public function it_throws_when_error_links_misses_about_link()
-    {
-        $parser = new LinksParser($this->createMock(MetaParser::class));
-
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Error links object MUST contain at least one of the following properties: `about`.');
-
-        $parser->parse(json_decode('{}', false), LinksParser::SOURCE_ERROR);
-    }
-
-    /**
-     * @test
-     */
     public function it_throws_when_relationship_links_misses_self_and_related_links()
     {
         $parser = new LinksParser($this->createMock(MetaParser::class));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

See title.

## Motivation and context

The [spec](https://jsonapi.org/format/#errors) [isn't unambiguous](https://discuss.jsonapi.org/t/errors-and-links/1227) about whether the error links object MUST contain an about member or not. We interpreted it as such, but I believe we should remove the restriction for now until it is clarified.

Closes #68 

## How has this been tested?

N/A

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
