### PR TITLE
Do not break out of loop when hydrating relations

### DIFF
--- a/src/ItemHydrator.php
+++ b/src/ItemHydrator.php
@@ -85,7 +85,7 @@ class ItemHydrator
             ) {
                 $relation->dissociate();
 
-                return;
+                continue;
             }
 
             // It is a valid relation

--- a/tests/ItemHydratorTest.php
+++ b/tests/ItemHydratorTest.php
@@ -525,6 +525,33 @@ class ItemHydratorTest extends AbstractTest
 
     /**
      * @test
+     */
+    public function it_dissociates_and_hydrates_relationships_in_one_call()
+    {
+        $data = [
+            'hasone_relation' => null,
+            'morphto_relation' => [
+                'id' => 1,
+                'type' => 'related-item',
+            ],
+        ];
+
+        $item = new WithRelationshipItem();
+        $item = $this->getItemHydrator()->hydrate($item, $data);
+
+        /** @var \Swis\JsonApi\Client\Relations\MorphToRelation $morphTo */
+        $morphTo = $item->getRelation('morphto_relation');
+        $this->assertInstanceOf(MorphToRelation::class, $morphTo);
+
+        $this->assertEquals($data['morphto_relation']['id'], $morphTo->getIncluded()->getId());
+        $this->assertEquals($data['morphto_relation']['type'], $morphTo->getIncluded()->getType());
+        $this->assertArrayNotHasKey('type', $morphTo->getIncluded()->getAttributes());
+
+        $this->assertArrayHasKey('morphto_relation', $item->toJsonApiArray()['relationships']);
+    }
+
+    /**
+     * @test
      * @dataProvider provideIdArguments
      *
      * @param $givenId


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I fixed a bug where the `ItemHydrator` does not hydrate relations following a relation that needs to be dissociated.

## Motivation and context

Bug introduced in #67 

## How has this been tested?

Tested with added unit test.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
