### PR TITLE
Add factory methods for DocumentClient, ResponseParser and DocumentParser

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -86,23 +86,20 @@ php artisan vendor:publish --provider="Swis\JsonApi\Client\Providers\ServiceProv
 
 ## Getting started
 
-You can simply require the [DocumentClient](#documentclient) as a dependency and use it in your class.
-Alternatively, you can create a repository based on `\Swis\JsonApi\Client\Repository` and use that as a dependency:
+You can simply create an instance of [DocumentClient](#documentclient) and use it in your class.
+Alternatively, you can create a [repository](#repository).
 
 ``` php
-use Swis\JsonApi\Client\Repository
+use Swis\JsonApi\Client\DocumentClient;
 
-class BlogRepository extends Repository
-{
-    protected $endpoint = 'blogs';
-}
+$client = DocumentClient::create();
+$document = $client->get('https://cms.contentacms.io/api/recipes');
 
-$repository = app(BlogRepository::class);
-$document = $repository->all();
-if ($document->hasErrors()) {
-   // do something with errors
-} else {
-  $blogs = $document->getData();
+/** @var \Swis\JsonApi\Client\Collection&\Swis\JsonApi\Client\Item[] $collection */
+$collection = $document->getData();
+
+foreach ($collection as $item) {
+  // Do stuff with the items
 }
 ```
 

--- a/src/DocumentClient.php
+++ b/src/DocumentClient.php
@@ -2,12 +2,15 @@
 
 namespace Swis\JsonApi\Client;
 
+use Psr\Http\Client\ClientInterface as HttpClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use Swis\JsonApi\Client\Interfaces\ClientInterface;
 use Swis\JsonApi\Client\Interfaces\DocumentClientInterface;
 use Swis\JsonApi\Client\Interfaces\DocumentInterface;
 use Swis\JsonApi\Client\Interfaces\ItemDocumentInterface;
 use Swis\JsonApi\Client\Interfaces\ResponseParserInterface;
+use Swis\JsonApi\Client\Interfaces\TypeMapperInterface;
+use Swis\JsonApi\Client\Parsers\ResponseParser;
 
 class DocumentClient implements DocumentClientInterface
 {
@@ -29,6 +32,17 @@ class DocumentClient implements DocumentClientInterface
     {
         $this->client = $client;
         $this->parser = $parser;
+    }
+
+    /**
+     * @param \Swis\JsonApi\Client\Interfaces\TypeMapperInterface|null $typeMapper
+     * @param \Psr\Http\Client\ClientInterface|null                    $client
+     *
+     * @return static
+     */
+    public static function create(TypeMapperInterface $typeMapper = null, HttpClientInterface $client = null): self
+    {
+        return new static(new Client($client), ResponseParser::create($typeMapper));
     }
 
     /**

--- a/src/Parsers/DocumentParser.php
+++ b/src/Parsers/DocumentParser.php
@@ -11,7 +11,9 @@ use Swis\JsonApi\Client\Interfaces\DocumentParserInterface;
 use Swis\JsonApi\Client\Interfaces\ItemInterface;
 use Swis\JsonApi\Client\Interfaces\ManyRelationInterface;
 use Swis\JsonApi\Client\Interfaces\OneRelationInterface;
+use Swis\JsonApi\Client\Interfaces\TypeMapperInterface;
 use Swis\JsonApi\Client\ItemDocument;
+use Swis\JsonApi\Client\TypeMapper;
 
 class DocumentParser implements DocumentParserInterface
 {
@@ -67,6 +69,29 @@ class DocumentParser implements DocumentParserInterface
         $this->linksParser = $linksParser;
         $this->jsonapiParser = $jsonapiParser;
         $this->metaParser = $metaParser;
+    }
+
+    /**
+     * @param \Swis\JsonApi\Client\Interfaces\TypeMapperInterface|null $typeMapper
+     *
+     * @return static
+     */
+    public static function create(TypeMapperInterface $typeMapper = null): self
+    {
+        $metaParser = new MetaParser();
+        $linksParser = new LinksParser($metaParser);
+        $itemParser = new ItemParser($typeMapper ?? new TypeMapper(), $linksParser, $metaParser);
+
+        return new static(
+            $itemParser,
+            new CollectionParser($itemParser),
+            new ErrorCollectionParser(
+                new ErrorParser($linksParser, $metaParser)
+            ),
+            $linksParser,
+            new JsonapiParser($metaParser),
+            $metaParser
+        );
     }
 
     /**

--- a/src/Parsers/ResponseParser.php
+++ b/src/Parsers/ResponseParser.php
@@ -7,6 +7,7 @@ use Swis\JsonApi\Client\Document;
 use Swis\JsonApi\Client\Interfaces\DocumentInterface;
 use Swis\JsonApi\Client\Interfaces\DocumentParserInterface;
 use Swis\JsonApi\Client\Interfaces\ResponseParserInterface;
+use Swis\JsonApi\Client\Interfaces\TypeMapperInterface;
 use Swis\JsonApi\Client\InvalidResponseDocument;
 
 class ResponseParser implements ResponseParserInterface
@@ -22,6 +23,16 @@ class ResponseParser implements ResponseParserInterface
     public function __construct(DocumentParserInterface $parser)
     {
         $this->parser = $parser;
+    }
+
+    /**
+     * @param \Swis\JsonApi\Client\Interfaces\TypeMapperInterface|null $typeMapper
+     *
+     * @return static
+     */
+    public static function create(TypeMapperInterface $typeMapper = null): self
+    {
+        return new static(DocumentParser::create($typeMapper));
     }
 
     /**

--- a/tests/DocumentClientTest.php
+++ b/tests/DocumentClientTest.php
@@ -15,6 +15,14 @@ class DocumentClientTest extends AbstractTest
     /**
      * @test
      */
+    public function it_can_create_an_instance_using_a_factory_method()
+    {
+        $this->assertInstanceOf(DocumentClient::class, DocumentClient::create());
+    }
+
+    /**
+     * @test
+     */
     public function the_base_url_can_be_changed_after_instantiation()
     {
         /** @var \PHPUnit\Framework\MockObject\MockObject|\Swis\JsonApi\Client\Interfaces\ClientInterface $client */

--- a/tests/Parsers/DocumentParserTest.php
+++ b/tests/Parsers/DocumentParserTest.php
@@ -14,14 +14,7 @@ use Swis\JsonApi\Client\Jsonapi;
 use Swis\JsonApi\Client\Link;
 use Swis\JsonApi\Client\Links;
 use Swis\JsonApi\Client\Meta;
-use Swis\JsonApi\Client\Parsers\CollectionParser;
 use Swis\JsonApi\Client\Parsers\DocumentParser;
-use Swis\JsonApi\Client\Parsers\ErrorCollectionParser;
-use Swis\JsonApi\Client\Parsers\ErrorParser;
-use Swis\JsonApi\Client\Parsers\ItemParser;
-use Swis\JsonApi\Client\Parsers\JsonapiParser;
-use Swis\JsonApi\Client\Parsers\LinksParser;
-use Swis\JsonApi\Client\Parsers\MetaParser;
 use Swis\JsonApi\Client\Tests\AbstractTest;
 use Swis\JsonApi\Client\Tests\Mocks\Items\ChildItem;
 use Swis\JsonApi\Client\Tests\Mocks\Items\MasterItem;
@@ -42,7 +35,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_converts_jsondocument_to_document()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
         $document = $parser->parse(
             json_encode(
                 [
@@ -59,7 +52,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_throws_when_json_is_not_valid()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Unable to parse JSON data: Malformed UTF-8 characters, possibly incorrectly encoded');
@@ -75,7 +68,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_throws_when_json_is_not_a_jsonapi_document(string $invalidJson)
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage(sprintf('Document MUST be an object, "%s" given.', gettype(json_decode($invalidJson, false))));
@@ -100,7 +93,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_throws_when_data_errors_and_meta_are_missing()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Document MUST contain at least one of the following properties: `data`, `errors`, `meta`.');
@@ -113,7 +106,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_throws_when_both_data_and_errors_are_present()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('The properties `data` and `errors` MUST NOT coexist in Document.');
@@ -126,7 +119,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_throws_when_included_is_present_but_data_is_not()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('If Document does not contain a `data` property, the `included` property MUST NOT be present either.');
@@ -142,7 +135,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_throws_when_data_is_not_an_array_object_or_null($invalidData)
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage(sprintf('Document property "data" MUST be null, an array or an object, "%s" given.', gettype(json_decode($invalidData, false)->data)));
@@ -168,7 +161,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_throws_when_included_is_not_an_array($invalidIncluded)
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage(sprintf('Document property "included" MUST be an array, "%s" given.', gettype(json_decode($invalidIncluded, false)->included)));
@@ -193,7 +186,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_throws_when_it_finds_duplicate_resources()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
 
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('Resources MUST be unique based on their `type` and `id`, 1 duplicate(s) found.');
@@ -229,7 +222,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_parses_a_resource_document()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
         $document = $parser->parse(
             json_encode(
                 [
@@ -255,7 +248,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_parses_a_resource_collection_document()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
         $document = $parser->parse(
             json_encode(
                 [
@@ -284,7 +277,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_parses_a_document_without_data()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
         $document = $parser->parse(
             json_encode(
                 [
@@ -303,7 +296,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_parses_included()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
         $document = $parser->parse(
             json_encode(
                 [
@@ -336,7 +329,7 @@ class DocumentParserTest extends AbstractTest
         $typeMapper = new TypeMapper();
         $typeMapper->setMapping('master', MasterItem::class);
         $typeMapper->setMapping('child', ChildItem::class);
-        $parser = $this->getDocumentParser($typeMapper);
+        $parser = DocumentParser::create($typeMapper);
 
         $document = $parser->parse(
             json_encode(
@@ -382,7 +375,7 @@ class DocumentParserTest extends AbstractTest
         $typeMapper = new TypeMapper();
         $typeMapper->setMapping('master', MasterItem::class);
         $typeMapper->setMapping('child', ChildItem::class);
-        $parser = $this->getDocumentParser($typeMapper);
+        $parser = DocumentParser::create($typeMapper);
 
         $document = $parser->parse(
             json_encode(
@@ -425,7 +418,7 @@ class DocumentParserTest extends AbstractTest
         $typeMapper = new TypeMapper();
         $typeMapper->setMapping('master', MasterItem::class);
         $typeMapper->setMapping('child', ChildItem::class);
-        $parser = $this->getDocumentParser($typeMapper);
+        $parser = DocumentParser::create($typeMapper);
 
         $document = $parser->parse(
             json_encode(
@@ -486,7 +479,7 @@ class DocumentParserTest extends AbstractTest
         $typeMapper = new TypeMapper();
         $typeMapper->setMapping('master', MasterItem::class);
         $typeMapper->setMapping('child', ChildItem::class);
-        $parser = $this->getDocumentParser($typeMapper);
+        $parser = DocumentParser::create($typeMapper);
 
         $document = $parser->parse(
             json_encode(
@@ -535,7 +528,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_parses_links()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
 
         $document = $parser->parse(
             json_encode(
@@ -558,7 +551,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_parses_errors()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
 
         $document = $parser->parse(
             json_encode(
@@ -583,7 +576,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_parses_meta()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
 
         $document = $parser->parse(
             json_encode(
@@ -606,7 +599,7 @@ class DocumentParserTest extends AbstractTest
      */
     public function it_parses_jsonapi()
     {
-        $parser = $this->getDocumentParser();
+        $parser = DocumentParser::create();
 
         $document = $parser->parse(
             json_encode(
@@ -622,21 +615,5 @@ class DocumentParserTest extends AbstractTest
         static::assertInstanceOf(Jsonapi::class, $document->getJsonapi());
 
         static::assertEquals(new Jsonapi('1.0'), $document->getJsonapi());
-    }
-
-    private function getDocumentParser(TypeMapper $typeMapper = null): DocumentParser
-    {
-        $metaParser = new MetaParser();
-        $linksParser = new LinksParser($metaParser);
-        $itemParser = new ItemParser($typeMapper ?? new TypeMapper(), $linksParser, $metaParser);
-
-        return new DocumentParser(
-            $itemParser,
-            new CollectionParser($itemParser),
-            new ErrorCollectionParser(new ErrorParser($linksParser, $metaParser)),
-            $linksParser,
-            new JsonapiParser($metaParser),
-            $metaParser
-        );
     }
 }

--- a/tests/Parsers/DocumentParserTest.php
+++ b/tests/Parsers/DocumentParserTest.php
@@ -32,6 +32,14 @@ class DocumentParserTest extends AbstractTest
     /**
      * @test
      */
+    public function it_can_create_an_instance_using_a_factory_method()
+    {
+        $this->assertInstanceOf(DocumentParser::class, DocumentParser::create());
+    }
+
+    /**
+     * @test
+     */
     public function it_converts_jsondocument_to_document()
     {
         $parser = $this->getDocumentParser();

--- a/tests/Parsers/ResponseParserTest.php
+++ b/tests/Parsers/ResponseParserTest.php
@@ -15,6 +15,14 @@ class ResponseParserTest extends AbstractTest
     /**
      * @test
      */
+    public function it_can_create_an_instance_using_a_factory_method()
+    {
+        $this->assertInstanceOf(ResponseParser::class, ResponseParser::create());
+    }
+
+    /**
+     * @test
+     */
     public function it_converts_psr_reponse_to_document()
     {
         $documentParser = $this->createMock(DocumentParser::class);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I've added factory methods to `DocumentClient`, `ResponseParser` and `DocumentParser`. All other parsers are internal and should not be used by consumers, so I didn't add a factory method to those.

## Motivation and context

As seen in https://github.com/swisnl/json-api-client/issues/74#issuecomment-673398487 setting up the `DocumentClient` or `ResponseParser` without a container is quit cumbersome and the user doesn't have to be bothered with internal implementation details. With these factory methods that example can be reduced to this:

```php
<?php
require '../vendor/autoload.php';

$client = \Swis\JsonApi\Client\DocumentClient::create();

$endpointUrl = 'https://cms.contentacms.io/api/recipes';
$response = $client->get($endpointUrl);

/** @var Swis\JsonApi\Client\Collection $collection */
$collection = $response->getData();

// While there is a "next" link there are more pages
while ($response->getLinks()->offsetExists('next')) {
  $response = $client->get($response->getLinks()->offsetGet('next')->getHref());

  // Merge the next page with the current collection
  $collection = $collection->merge($response->getData());
}

/** @var \Swis\JsonApi\Client\Item $item */
foreach ($collection as $item) {
  // Do stuff with the items
  if ($item->hasAttribute('title')) {
    echo $item->title . '<br>';
  }
}
```

## How has this been tested?

Added unit tests and example above.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
