### PR TITLE
Do not prepend the base uri if the endpoint is already absolute

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -195,6 +195,10 @@ class Client implements ClientInterface
      */
     protected function getEndpoint(string $endpoint): string
     {
+        if (strpos($endpoint, 'http://') === 0 || strpos($endpoint, 'https://') === 0) {
+            return $endpoint;
+        }
+
         return $this->baseUri.$endpoint;
     }
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -234,4 +234,38 @@ class ClientTest extends AbstractTest
         $this->assertInstanceOf(ResponseInterface::class, $response);
         $this->assertEquals('', (string) $httpClient->getLastRequest()->getBody());
     }
+
+    /**
+     * @test
+     */
+    public function it_prepends_the_base_uri_if_the_endpoint_is_relative()
+    {
+        $baseUri = 'http://example.com/api';
+        $endpoint = '/test/1';
+
+        $httpClient = new HttpMockClient();
+        $client = new Client($httpClient);
+        $client->setBaseUri($baseUri);
+
+        $client->get($endpoint);
+
+        $this->assertEquals($baseUri.$endpoint, $httpClient->getLastRequest()->getUri());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_prepend_the_base_uri_if_the_endpoint_is_already_absolute()
+    {
+        $baseUri = 'http://example.com/api';
+        $endpoint = 'http://foo.bar/test/1';
+
+        $httpClient = new HttpMockClient();
+        $client = new Client($httpClient);
+        $client->setBaseUri($baseUri);
+
+        $client->get($endpoint);
+
+        $this->assertEquals($endpoint, $httpClient->getLastRequest()->getUri());
+    }
 }


### PR DESCRIPTION
## Description

I changed the client so it does not prepend the base uri if the endpoint url is already absolute (starting with `http://` or `https://`).

## Motivation and context

The spec states that links should be absolute, so it is inconvenient if you want to use those directly and the client prepends the base uri, resulting in an incorrect url.

## How has this been tested?

Added extra unit tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
