### PR TITLE
Bug: data.meta ignored in relationships

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -115,14 +115,6 @@ class Item extends Model implements ItemInterface
     }
 
     /**
-     * @return Meta
-     */
-    public function getDataMeta(): Meta
-    {
-        return $this->meta;
-    }
-
-    /**
      * @return array
      */
     public function getAvailableRelations(): array
@@ -150,15 +142,22 @@ class Item extends Model implements ItemInterface
                         'type' => $relation->getIncluded()->getType(),
                         'id' => $relation->getIncluded()->getId(),
                     ];
+                    if ($relation->getIncluded()->getMeta()) {
+                        $relationships[$name]['data']['meta'] = $relation->getIncluded()->getMeta()->toArray();
+                    }
                 }
             } elseif ($relation instanceof ManyRelationInterface) {
                 $relationships[$name]['data'] = [];
 
                 foreach ($relation->getIncluded() as $item) {
-                    $relationships[$name]['data'][] = [
+                    $data = [
                         'type' => $item->getType(),
                         'id' => $item->getId(),
                     ];
+                    if ($item->getMeta()) {
+                        $data['meta'] = $item->getMeta()->toArray();
+                    }
+                    $relationships[$name]['data'][] = $data;
                 }
             }
 

--- a/src/Item.php
+++ b/src/Item.php
@@ -115,6 +115,14 @@ class Item extends Model implements ItemInterface
     }
 
     /**
+     * @return Meta
+     */
+    public function getDataMeta(): Meta
+    {
+        return $this->meta;
+    }
+
+    /**
      * @return array
      */
     public function getAvailableRelations(): array

--- a/src/Parsers/ItemParser.php
+++ b/src/Parsers/ItemParser.php
@@ -191,6 +191,11 @@ class ItemParser
             throw new ValidationException(sprintf('ResourceIdentifier property "id" MUST be a string, "%s" given.', gettype($data->id)));
         }
 
-        return $this->getItemInstance($data->type)->setId($data->id);
+        $item = $this->getItemInstance($data->type)->setId($data->id);
+        if (property_exists($data, 'meta')) {
+            $item->setMeta($this->metaParser->parse($data->meta));
+        }
+
+        return $item;
     }
 }

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -511,7 +511,9 @@ class ItemTest extends AbstractTest
         $masterItem = new MasterItem();
         $childItem = new ChildItem();
         $childItem->setId('1');
+        $childItem->setMeta(new Meta(['foo' => 'bar']));
         $masterItem->child()->associate($childItem);
+        $masterItem->children()->associate(new Collection([$childItem]));
 
         $relations = $masterItem->getRelationships();
 
@@ -520,6 +522,20 @@ class ItemTest extends AbstractTest
                 'data' => [
                     'type' => 'child',
                     'id' => '1',
+                    'meta' => [
+                        'foo' => 'bar',
+                    ],
+                ],
+            ],
+            'children' => [
+                'data' => [
+                    [
+                        'type' => 'child',
+                        'id' => '1',
+                        'meta' => [
+                            'foo' => 'bar',
+                        ],
+                    ],
                 ],
             ],
         ], $relations);

--- a/tests/Parsers/ItemParserTest.php
+++ b/tests/Parsers/ItemParserTest.php
@@ -657,7 +657,7 @@ class ItemParserTest extends AbstractTest
 
         $item = $parser->parse($this->getJsonApiItemMock('master', '1'));
 
-        $dataMeta = $item->getRelation('childwithdatameta')->getIncluded()->getDataMeta();
+        $dataMeta = $item->getRelation('childwithdatameta')->getIncluded()->getMeta();
         static::assertInstanceOf(Meta::class, $dataMeta);
 
         $image = $dataMeta->imageDerivatives->links->header->href;

--- a/tests/Parsers/ItemParserTest.php
+++ b/tests/Parsers/ItemParserTest.php
@@ -646,6 +646,25 @@ class ItemParserTest extends AbstractTest
     }
 
     /**
+     * @test
+     */
+    public function itParsesMetaInData()
+    {
+        $typeMapper = new TypeMapper();
+        $typeMapper->setMapping('child', ChildItem::class);
+        $typeMapper->setMapping('master', MasterItem::class);
+        $parser = $this->getItemParser($typeMapper);
+
+        $item = $parser->parse($this->getJsonApiItemMock('master', '1'));
+
+        $dataMeta = $item->getRelation('childwithdatameta')->getIncluded()->getDataMeta();
+        static::assertInstanceOf(Meta::class, $dataMeta);
+
+        $image = $dataMeta->imageDerivatives->links->header->href;
+        $this->assertEquals('https://example.com/image/header/about-us.jpeg', $image);
+    }
+
+    /**
      * @param \Swis\JsonApi\Client\Interfaces\TypeMapperInterface|null $typeMapper
      *
      * @return \Swis\JsonApi\Client\Parsers\ItemParser
@@ -764,6 +783,30 @@ class ItemParserTest extends AbstractTest
                     ],
                     'meta' => [
                         'foo' => 'bar',
+                    ],
+                ],
+                'childwithdatameta' => [
+                    'data' => [
+                        'type' => 'child',
+                        'id' => '9',
+                        'meta' => [
+                          'alt' => '',
+                          'width' => 1920,
+                          'height' => 1280,
+                          'imageDerivatives' => [
+                            'links' => [
+                              'header' => [
+                                'href' => 'https://example.com/image/header/about-us.jpeg',
+                                'meta' => [
+                                  'rel' => 'drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative',
+                                ],
+                              ],
+                            ],
+                          ],
+                        ],
+                    ],
+                    'links' => [
+                        'self' => 'http://example.com/'.$type.'/'.$id.'/relationships/childwithdatameta',
                     ],
                 ],
                 'empty' => [


### PR DESCRIPTION
## Detailed description

A JSON:API [resource linkage](https://jsonapi.org/format/#document-resource-object-linkage) in a [relationship object](https://jsonapi.org/format/#document-resource-object-relationships) may also include a [`meta` member](https://jsonapi.org/format/#document-resource-identifier-objects), but `json-api-client` doesn't check for this, which is a bug.

Specifically, I'm integrating with a Drupal 9.1.0 JSON:API in which I've enabled the Drupal `consumer_image_styles` module in order to add image style information to an image field in a content entity. The relevant part in the `relationships` API response looks like this:

```json
"field_header_image": {
  "data": {
    "type": "file--file",
    "id": "bb7912a9-81ed-4c58-8e11-37d4d619e8a5",
    "meta": {
      "alt": "",
      "title": "",
      "width": 1920,
      "height": 1280,
      "imageDerivatives": {
        "links": {
          "header": {
            "href": "https://example.com/sites/default/files/styles/header/public/header/2021-01/about-us-header.jpeg?h=e5aec6c8&itok=qXnhaDF4",
            "meta": {
              "rel": [
                "drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative"
              ]
            }
          },
          "header_600x431_": {
            "href": "https://example.com/sites/default/files/styles/header_600x431_/public/header/2021-01/about-us-header.jpeg?h=e5aec6c8&itok=qEH6iDvL",
            "meta": {
              "rel": [
                "drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative"
              ]
            }
          }
        }
      }
    }
  }
```

Note that `meta` is a property of `data`.

The place in the code which should check for this is in the  [ItemParser's parseRelationshipData()](https://github.com/swisnl/json-api-client/blob/1.x/src/Parsers/ItemParser.php#L194).

Instead, the `return` should be changed to:

```php
        $item = $this->getItemInstance($data->type)->setId($data->id);
        if (property_exists($data, 'meta')) {
            $item->setMeta($this->metaParser->parse($data->meta));
        }
        return $item;
``` 

## Context

This helps me integrate with a Drupal JSON:API so that I can get various resized images.

## My environment

* PHP 7.4
* Mac OS 10.14.6 running Valet