### PR TITLE
Declare strict types

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,6 +9,7 @@ $finder = (new PhpCsFixer\Finder())
 
 return (new PhpCsFixer\Config())
     ->setFinder($finder)
+    ->setRiskyAllowed(true)
     ->setRules([
         '@Symfony' => true,
         'array_syntax' => ['syntax' => 'short'],
@@ -18,5 +19,6 @@ return (new PhpCsFixer\Config())
         'phpdoc_order' => true,
         'yoda_style' => false,
         'no_superfluous_phpdoc_tags' => false,
+        'declare_strict_types' => true,
     ])
 ;

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use Http\Discovery\Psr17FactoryDiscovery;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use Swis\JsonApi\Client\Interfaces\DataInterface;

--- a/src/CollectionDocument.php
+++ b/src/CollectionDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use Swis\JsonApi\Client\Interfaces\CollectionDocumentInterface;

--- a/src/Concerns/GuardsAttributes.php
+++ b/src/Concerns/GuardsAttributes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Concerns;
 
 trait GuardsAttributes

--- a/src/Concerns/HasAttributes.php
+++ b/src/Concerns/HasAttributes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Concerns;
 
 use Illuminate\Contracts\Support\Arrayable;

--- a/src/Concerns/HasId.php
+++ b/src/Concerns/HasId.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Concerns;
 
 trait HasId

--- a/src/Concerns/HasInitial.php
+++ b/src/Concerns/HasInitial.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Concerns;
 
 trait HasInitial

--- a/src/Concerns/HasLinks.php
+++ b/src/Concerns/HasLinks.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Concerns;
 
 use Swis\JsonApi\Client\Links;

--- a/src/Concerns/HasMeta.php
+++ b/src/Concerns/HasMeta.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Concerns;
 
 use Swis\JsonApi\Client\Meta;

--- a/src/Concerns/HasRelations.php
+++ b/src/Concerns/HasRelations.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Concerns;
 
 use Swis\JsonApi\Client\Collection;

--- a/src/Concerns/HasType.php
+++ b/src/Concerns/HasType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Concerns;
 
 trait HasType

--- a/src/Concerns/HidesAttributes.php
+++ b/src/Concerns/HidesAttributes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Concerns;
 
 trait HidesAttributes

--- a/src/Document.php
+++ b/src/Document.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use Psr\Http\Message\ResponseInterface;

--- a/src/DocumentClient.php
+++ b/src/DocumentClient.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use Psr\Http\Client\ClientInterface as HttpClientInterface;

--- a/src/DocumentFactory.php
+++ b/src/DocumentFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use Swis\JsonApi\Client\Exceptions\UnsupportedDataException;

--- a/src/Error.php
+++ b/src/Error.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use Swis\JsonApi\Client\Concerns\HasLinks;

--- a/src/ErrorCollection.php
+++ b/src/ErrorCollection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 class ErrorCollection extends \Illuminate\Support\Collection

--- a/src/ErrorSource.php
+++ b/src/ErrorSource.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 class ErrorSource

--- a/src/Exceptions/Exception.php
+++ b/src/Exceptions/Exception.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Exceptions;
 
 interface Exception

--- a/src/Exceptions/HydrationException.php
+++ b/src/Exceptions/HydrationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Exceptions;
 
 use InvalidArgumentException;

--- a/src/Exceptions/MassAssignmentException.php
+++ b/src/Exceptions/MassAssignmentException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Exceptions;
 
 class MassAssignmentException extends \RuntimeException

--- a/src/Exceptions/TypeMappingException.php
+++ b/src/Exceptions/TypeMappingException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Exceptions;
 
 use InvalidArgumentException;

--- a/src/Exceptions/UnsupportedDataException.php
+++ b/src/Exceptions/UnsupportedDataException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Exceptions;
 
 use InvalidArgumentException;

--- a/src/Exceptions/ValidationException.php
+++ b/src/Exceptions/ValidationException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Exceptions;
 
 class ValidationException extends \InvalidArgumentException implements Exception

--- a/src/Interfaces/ClientInterface.php
+++ b/src/Interfaces/ClientInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 use Psr\Http\Message\ResponseInterface;

--- a/src/Interfaces/CollectionDocumentInterface.php
+++ b/src/Interfaces/CollectionDocumentInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 interface CollectionDocumentInterface extends DocumentInterface

--- a/src/Interfaces/DataInterface.php
+++ b/src/Interfaces/DataInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 interface DataInterface

--- a/src/Interfaces/DocumentClientInterface.php
+++ b/src/Interfaces/DocumentClientInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 interface DocumentClientInterface

--- a/src/Interfaces/DocumentInterface.php
+++ b/src/Interfaces/DocumentInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 use Psr\Http\Message\ResponseInterface;

--- a/src/Interfaces/DocumentParserInterface.php
+++ b/src/Interfaces/DocumentParserInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 interface DocumentParserInterface

--- a/src/Interfaces/ItemDocumentInterface.php
+++ b/src/Interfaces/ItemDocumentInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 interface ItemDocumentInterface extends DocumentInterface

--- a/src/Interfaces/ItemInterface.php
+++ b/src/Interfaces/ItemInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 use Swis\JsonApi\Client\Links;

--- a/src/Interfaces/ManyRelationInterface.php
+++ b/src/Interfaces/ManyRelationInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 use Swis\JsonApi\Client\Collection;

--- a/src/Interfaces/OneRelationInterface.php
+++ b/src/Interfaces/OneRelationInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 use Swis\JsonApi\Client\Links;

--- a/src/Interfaces/RepositoryInterface.php
+++ b/src/Interfaces/RepositoryInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 interface RepositoryInterface

--- a/src/Interfaces/ResponseParserInterface.php
+++ b/src/Interfaces/ResponseParserInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 use Psr\Http\Message\ResponseInterface;

--- a/src/Interfaces/TypeMapperInterface.php
+++ b/src/Interfaces/TypeMapperInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 /**

--- a/src/Interfaces/TypedRelationInterface.php
+++ b/src/Interfaces/TypedRelationInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Interfaces;
 
 interface TypedRelationInterface

--- a/src/InvalidResponseDocument.php
+++ b/src/InvalidResponseDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 class InvalidResponseDocument extends Document

--- a/src/Item.php
+++ b/src/Item.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use ArrayAccess;
@@ -378,7 +380,7 @@ class Item implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, ItemIn
     public function offsetSet($offset, $value)
     {
         if ($offset === 'id') {
-            $this->setId($value);
+            $this->setId($value ? (string) $value : null);
 
             return;
         }
@@ -396,7 +398,7 @@ class Item implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, ItemIn
     public function offsetUnset($offset)
     {
         if ($offset === 'id') {
-            $this->id = null;
+            $this->setId(null);
         }
 
         unset($this->attributes[$offset], $this->relations[$offset]);

--- a/src/ItemDocument.php
+++ b/src/ItemDocument.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use Swis\JsonApi\Client\Interfaces\ItemDocumentInterface;

--- a/src/ItemHydrator.php
+++ b/src/ItemHydrator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use Swis\JsonApi\Client\Exceptions\HydrationException;
@@ -202,6 +204,6 @@ class ItemHydrator
             $item = $this->typeMapper->getMapping($type);
         }
 
-        return $this->hydrate($item, $attributes, $attributes['id']);
+        return $this->hydrate($item, $attributes, (string) $attributes['id']);
     }
 }

--- a/src/Jsonapi.php
+++ b/src/Jsonapi.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use Illuminate\Contracts\Support\Arrayable;

--- a/src/Link.php
+++ b/src/Link.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use Swis\JsonApi\Client\Concerns\HasMeta;

--- a/src/Links.php
+++ b/src/Links.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use ArrayAccess;

--- a/src/Meta.php
+++ b/src/Meta.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use ArrayAccess;

--- a/src/Parsers/CollectionParser.php
+++ b/src/Parsers/CollectionParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Parsers;
 
 use Swis\JsonApi\Client\Collection;

--- a/src/Parsers/DocumentParser.php
+++ b/src/Parsers/DocumentParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Parsers;
 
 use Swis\JsonApi\Client\Collection;

--- a/src/Parsers/ErrorCollectionParser.php
+++ b/src/Parsers/ErrorCollectionParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Parsers;
 
 use Swis\JsonApi\Client\ErrorCollection;

--- a/src/Parsers/ErrorParser.php
+++ b/src/Parsers/ErrorParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Parsers;
 
 use Swis\JsonApi\Client\Error;

--- a/src/Parsers/ItemParser.php
+++ b/src/Parsers/ItemParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Parsers;
 
 use Swis\JsonApi\Client\Collection;
@@ -73,10 +75,7 @@ class ItemParser
         }
 
         $item = $this->getItemInstance($data->type);
-
-        if (property_exists($data, 'id')) {
-            $item->setId($data->id);
-        }
+        $item->setId((string) $data->id);
 
         if (property_exists($data, 'attributes')) {
             $item->fill((array) $data->attributes);
@@ -191,7 +190,7 @@ class ItemParser
             throw new ValidationException(sprintf('ResourceIdentifier property "id" MUST be a string, "%s" given.', gettype($data->id)));
         }
 
-        $item = $this->getItemInstance($data->type)->setId($data->id);
+        $item = $this->getItemInstance($data->type)->setId((string) $data->id);
         if (property_exists($data, 'meta')) {
             $item->setMeta($this->metaParser->parse($data->meta));
         }

--- a/src/Parsers/JsonapiParser.php
+++ b/src/Parsers/JsonapiParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Parsers;
 
 use Swis\JsonApi\Client\Exceptions\ValidationException;

--- a/src/Parsers/LinksParser.php
+++ b/src/Parsers/LinksParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Parsers;
 
 use Swis\JsonApi\Client\Collection;

--- a/src/Parsers/MetaParser.php
+++ b/src/Parsers/MetaParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Parsers;
 
 use Swis\JsonApi\Client\Exceptions\ValidationException;

--- a/src/Parsers/ResponseParser.php
+++ b/src/Parsers/ResponseParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Parsers;
 
 use Psr\Http\Message\ResponseInterface;

--- a/src/Relations/AbstractManyRelation.php
+++ b/src/Relations/AbstractManyRelation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Relations;
 
 use Swis\JsonApi\Client\Collection;

--- a/src/Relations/AbstractOneRelation.php
+++ b/src/Relations/AbstractOneRelation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Relations;
 
 use Swis\JsonApi\Client\Interfaces\ItemInterface;

--- a/src/Relations/AbstractRelation.php
+++ b/src/Relations/AbstractRelation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Relations;
 
 use Swis\JsonApi\Client\Concerns\HasLinks;

--- a/src/Relations/HasManyRelation.php
+++ b/src/Relations/HasManyRelation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Relations;
 
 use Swis\JsonApi\Client\Concerns\HasType;

--- a/src/Relations/HasOneRelation.php
+++ b/src/Relations/HasOneRelation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Relations;
 
 use Swis\JsonApi\Client\Concerns\HasType;

--- a/src/Relations/MorphToManyRelation.php
+++ b/src/Relations/MorphToManyRelation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Relations;
 
 class MorphToManyRelation extends AbstractManyRelation

--- a/src/Relations/MorphToRelation.php
+++ b/src/Relations/MorphToRelation.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Relations;
 
 class MorphToRelation extends AbstractOneRelation

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use Swis\JsonApi\Client\Interfaces\DocumentClientInterface;

--- a/src/TypeMapper.php
+++ b/src/TypeMapper.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 use Swis\JsonApi\Client\Exceptions\TypeMappingException;

--- a/src/Util.php
+++ b/src/Util.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client;
 
 class Util

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests;
 
 use GuzzleHttp\Psr7\Utils;

--- a/tests/Concerns/HasIdTest.php
+++ b/tests/Concerns/HasIdTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Concerns;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Concerns/HasInitialTest.php
+++ b/tests/Concerns/HasInitialTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Concerns;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Concerns/HasLinksTest.php
+++ b/tests/Concerns/HasLinksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Concerns;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Concerns/HasMetaTest.php
+++ b/tests/Concerns/HasMetaTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Concerns;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Concerns/HasRelationsTest.php
+++ b/tests/Concerns/HasRelationsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Concerns;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Concerns/HasTypeTest.php
+++ b/tests/Concerns/HasTypeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Concerns;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/DocumentClientTest.php
+++ b/tests/DocumentClientTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/DocumentFactoryTest.php
+++ b/tests/DocumentFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests;
 
 use GuzzleHttp\Psr7\Response;
@@ -141,14 +143,14 @@ class DocumentTest extends TestCase
         $document->setData(
             (new Item(['title' => 'JSON:API paints my bikeshed!']))
                 ->setType('articles')
-                ->setId(1)
+                ->setId('1')
         );
         $document->setIncluded(
             new Collection(
                 [
                     (new Item(['firstName' => 'Dan', 'lastName' => 'Gebhardt', 'twitter' => 'dgeb']))
                         ->setType('people')
-                        ->setId(9),
+                        ->setId('9'),
                 ]
             )
         );

--- a/tests/ItemHydratorTest.php
+++ b/tests/ItemHydratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests;
 
 use PHPUnit\Framework\TestCase;
@@ -44,7 +46,7 @@ class ItemHydratorTest extends TestCase
             'testobject' => [
                 'foo' => 'bar',
             ],
-            'testarray' => [1, 2, 3],
+            'testarray' => ['1', '2', '3'],
         ];
 
         $item = new Item();
@@ -59,7 +61,7 @@ class ItemHydratorTest extends TestCase
     public function itHydratesHasoneRelationshipsById()
     {
         $data = [
-            'hasone_relation' => 1,
+            'hasone_relation' => '1',
         ];
 
         $item = new WithRelationshipItem();
@@ -82,7 +84,7 @@ class ItemHydratorTest extends TestCase
     {
         $data = [
             'hasone_relation' => [
-                'id' => 1,
+                'id' => '1',
                 'test_related_attribute1' => 'test',
                 'test_related_attribute2' => 'test2',
             ],
@@ -132,8 +134,8 @@ class ItemHydratorTest extends TestCase
     {
         $data = [
             'hasmany_relation' => [
-                1,
-                2,
+                '1',
+                '2',
             ],
         ];
 
@@ -163,12 +165,12 @@ class ItemHydratorTest extends TestCase
         $data = [
             'hasmany_relation' => [
                 [
-                    'id' => 1,
+                    'id' => '1',
                     'test_related_attribute1' => 'test',
                     'test_related_attribute2' => 'test2',
                 ],
                 [
-                    'id' => 2,
+                    'id' => '2',
                     'test_related_attribute1' => 'test',
                     'test_related_attribute2' => 'test2',
                 ],
@@ -226,7 +228,7 @@ class ItemHydratorTest extends TestCase
     {
         $data = [
             'morphto_relation' => [
-                'id' => 1,
+                'id' => '1',
                 'type' => 'related-item',
             ],
         ];
@@ -252,7 +254,7 @@ class ItemHydratorTest extends TestCase
     {
         $data = [
             'morphto_relation' => [
-                'id' => 1,
+                'id' => '1',
                 'type' => 'related-item',
                 'test_related_attribute1' => 'test',
             ],
@@ -302,7 +304,7 @@ class ItemHydratorTest extends TestCase
     {
         $data = [
             'morphto_relation' => [
-                'id' => 1,
+                'id' => '1',
                 'type' => 'unmapped-item',
             ],
         ];
@@ -326,7 +328,7 @@ class ItemHydratorTest extends TestCase
     {
         $data = [
             'morphto_relation' => [
-                'id' => 1,
+                'id' => '1',
                 'test_related_attribute1' => 'test',
             ],
         ];
@@ -345,11 +347,11 @@ class ItemHydratorTest extends TestCase
         $data = [
             'morphtomany_relation' => [
                 [
-                    'id' => 1,
+                    'id' => '1',
                     'type' => 'related-item',
                 ],
                 [
-                    'id' => 2,
+                    'id' => '2',
                     'type' => 'another-related-item',
                 ],
             ],
@@ -383,12 +385,12 @@ class ItemHydratorTest extends TestCase
         $data = [
             'morphtomany_relation' => [
                 [
-                    'id' => 1,
+                    'id' => '1',
                     'type' => 'related-item',
                     'test_related_attribute1' => 'test1',
                 ],
                 [
-                    'id' => 2,
+                    'id' => '2',
                     'type' => 'another-related-item',
                     'test_related_attribute1' => 'test2',
                 ],
@@ -447,11 +449,11 @@ class ItemHydratorTest extends TestCase
         $data = [
             'morphtomany_relation' => [
                 [
-                    'id' => 1,
+                    'id' => '1',
                     'type' => 'unmapped-item',
                 ],
                 [
-                    'id' => 2,
+                    'id' => '2',
                     'type' => 'unmapped-item',
                 ],
             ],
@@ -482,7 +484,7 @@ class ItemHydratorTest extends TestCase
         $data = [
             'morphtomany_relation' => [
                 [
-                    'id' => 1,
+                    'id' => '1',
                     'test_related_attribute1' => 'test',
                 ],
             ],
@@ -501,8 +503,8 @@ class ItemHydratorTest extends TestCase
     {
         $data = [
             'hasone_relation' => [
-                'id' => 1,
-                'parent_relation' => 5,
+                'id' => '1',
+                'parent_relation' => '5',
             ],
         ];
 
@@ -532,7 +534,7 @@ class ItemHydratorTest extends TestCase
         $data = [
             'hasone_relation' => null,
             'morphto_relation' => [
-                'id' => 1,
+                'id' => '1',
                 'type' => 'related-item',
             ],
         ];
@@ -583,7 +585,7 @@ class ItemHydratorTest extends TestCase
     public function itThrowsWhenRelationshipIsPresentInAvailableRelationshipsButTheMethodDoesNotExist()
     {
         $data = [
-            'does_not_exist' => 1,
+            'does_not_exist' => '1',
         ];
 
         $item = new MasterItem();

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/LinksTest.php
+++ b/tests/LinksTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/MetaTest.php
+++ b/tests/MetaTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Parsers/CollectionParserTest.php
+++ b/tests/Parsers/CollectionParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Parsers;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Parsers/DocumentParserTest.php
+++ b/tests/Parsers/DocumentParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Parsers;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Parsers/ErrorCollectionParserTest.php
+++ b/tests/Parsers/ErrorCollectionParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Parsers;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Parsers/ErrorParserTest.php
+++ b/tests/Parsers/ErrorParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Parsers;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Parsers/ItemParserTest.php
+++ b/tests/Parsers/ItemParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Parsers;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Parsers/JsonapiParserTest.php
+++ b/tests/Parsers/JsonapiParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Parsers;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Parsers/LinksParserTest.php
+++ b/tests/Parsers/LinksParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Parsers;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Parsers/MetaParserTest.php
+++ b/tests/Parsers/MetaParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Parsers;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Parsers/ResponseParserTest.php
+++ b/tests/Parsers/ResponseParserTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Parsers;
 
 use GuzzleHttp\Psr7\Response;

--- a/tests/Relations/AbstractManyRelationTest.php
+++ b/tests/Relations/AbstractManyRelationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Relations;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Relations/AbstractOneRelationTest.php
+++ b/tests/Relations/AbstractOneRelationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Relations;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/RepositoryTest.php
+++ b/tests/RepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests;
 
 use PHPUnit\Framework\TestCase;
@@ -93,7 +95,7 @@ class RepositoryTest extends TestCase
 
         $repository = new MockRepository($client, new DocumentFactory());
 
-        $this->assertSame($document, $repository->find(1, ['foo' => 'bar']));
+        $this->assertSame($document, $repository->find('1', ['foo' => 'bar']));
     }
 
     /**
@@ -123,7 +125,7 @@ class RepositoryTest extends TestCase
     public function itCanSaveExisting()
     {
         $document = new ItemDocument();
-        $document->setData((new Item())->setId(1));
+        $document->setData((new Item())->setId('1'));
 
         /** @var \PHPUnit\Framework\MockObject\MockObject|\Swis\JsonApi\Client\Interfaces\DocumentClientInterface $client */
         $client = $this->createMock(DocumentClientInterface::class);
@@ -135,7 +137,7 @@ class RepositoryTest extends TestCase
 
         $repository = new MockRepository($client, new DocumentFactory());
 
-        $this->assertSame($document, $repository->save((new Item())->setId(1), ['foo' => 'bar']));
+        $this->assertSame($document, $repository->save((new Item())->setId('1'), ['foo' => 'bar']));
     }
 
     /**
@@ -155,6 +157,6 @@ class RepositoryTest extends TestCase
 
         $repository = new MockRepository($client, new DocumentFactory());
 
-        $this->assertSame($document, $repository->delete(1, ['foo' => 'bar']));
+        $this->assertSame($document, $repository->delete('1', ['foo' => 'bar']));
     }
 }

--- a/tests/TypeMapperTest.php
+++ b/tests/TypeMapperTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\TestCase;
 use Swis\JsonApi\Client\Util;
 

--- a/tests/_mocks/ItemStub.php
+++ b/tests/_mocks/ItemStub.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Mocks;
 
 use DateTime;
@@ -63,7 +65,7 @@ class ItemStub extends Item
 
     public function getAgeAttribute($value)
     {
-        $date = DateTime::createFromFormat('U', $this->attributes['birthday']);
+        $date = DateTime::createFromFormat('U', (string) $this->attributes['birthday']);
 
         return $date->diff(new DateTime('now'))->y;
     }

--- a/tests/_mocks/Items/AnotherRelatedItem.php
+++ b/tests/_mocks/Items/AnotherRelatedItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Mocks\Items;
 
 use Swis\JsonApi\Client\Item;

--- a/tests/_mocks/Items/ChildItem.php
+++ b/tests/_mocks/Items/ChildItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Mocks\Items;
 
 use Swis\JsonApi\Client\Item;

--- a/tests/_mocks/Items/MasterItem.php
+++ b/tests/_mocks/Items/MasterItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Mocks\Items;
 
 use Swis\JsonApi\Client\Item;

--- a/tests/_mocks/Items/PlainItem.php
+++ b/tests/_mocks/Items/PlainItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Mocks\Items;
 
 use Swis\JsonApi\Client\Item;

--- a/tests/_mocks/Items/RelatedItem.php
+++ b/tests/_mocks/Items/RelatedItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Mocks\Items;
 
 use Swis\JsonApi\Client\Item;

--- a/tests/_mocks/Items/WithHiddenItem.php
+++ b/tests/_mocks/Items/WithHiddenItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Mocks\Items;
 
 use Swis\JsonApi\Client\Item;

--- a/tests/_mocks/Items/WithRelationshipItem.php
+++ b/tests/_mocks/Items/WithRelationshipItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Mocks\Items;
 
 use Swis\JsonApi\Client\Item;

--- a/tests/_mocks/Items/WithoutRelationshipsItem.php
+++ b/tests/_mocks/Items/WithoutRelationshipsItem.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Mocks\Items;
 
 use Swis\JsonApi\Client\Item;

--- a/tests/_mocks/MockRepository.php
+++ b/tests/_mocks/MockRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Swis\JsonApi\Client\Tests\Mocks;
 
 use Swis\JsonApi\Client\Repository;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I've declared strict types in all classes and also configured PHP-CS-Fixer to make it required.

## Motivation and context

To improve code quality and reduce errors.

N.B. Sometimes an id is provided as integer and we don't want to break on that small detail, so I cast them to a string before setting them on the item. Since the type declaration of the id was already a string the output won't change.

## How has this been tested?

Tested in a real life application.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

N.B. Declaring strict types can be considered a breaking change, but since we already have strict type checks in our parsers and I added the cast for the ID's, I believe the vast majority of users will not be affected.

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
