### PR TITLE
Keep relationship data when linking items from included

### DIFF
--- a/src/Concerns/HasRelations.php
+++ b/src/Concerns/HasRelations.php
@@ -160,13 +160,13 @@ trait HasRelations
         // it is a relationship and will load and return the included items in the relationship
         $method = Util::stringCamel($name);
         if (method_exists($this, $method)) {
-            return $this->$method()->getIncluded();
+            return $this->$method()->getAssociated();
         }
 
         // If the "attribute" exists as a relationship on the model, we will return
         // the included items in the relationship
         if ($this->hasRelation($name)) {
-            return $this->getRelation($name)->getIncluded();
+            return $this->getRelation($name)->getAssociated();
         }
 
         return null;

--- a/src/Interfaces/ManyRelationInterface.php
+++ b/src/Interfaces/ManyRelationInterface.php
@@ -11,6 +11,36 @@ use Swis\JsonApi\Client\Meta;
 interface ManyRelationInterface
 {
     /**
+     * @param \Swis\JsonApi\Client\Collection|null $data
+     */
+    public function setData(?Collection $data);
+
+    /**
+     * @return \Swis\JsonApi\Client\Collection|null
+     */
+    public function getData(): ?Collection;
+
+    /**
+     * @return bool
+     */
+    public function hasData(): bool;
+
+    /**
+     * @param \Swis\JsonApi\Client\Collection $included
+     */
+    public function setIncluded(Collection $included);
+
+    /**
+     * @return \Swis\JsonApi\Client\Collection
+     */
+    public function getIncluded(): Collection;
+
+    /**
+     * @return bool
+     */
+    public function hasIncluded(): bool;
+
+    /**
      * @param \Swis\JsonApi\Client\Collection $included
      *
      * @return static
@@ -23,14 +53,14 @@ interface ManyRelationInterface
     public function dissociate();
 
     /**
-     * @return bool
-     */
-    public function hasIncluded(): bool;
-
-    /**
      * @return \Swis\JsonApi\Client\Collection
      */
-    public function getIncluded(): Collection;
+    public function getAssociated(): Collection;
+
+    /**
+     * @return bool
+     */
+    public function hasAssociated(): bool;
 
     /**
      * @param bool $omitIncluded

--- a/src/Interfaces/OneRelationInterface.php
+++ b/src/Interfaces/OneRelationInterface.php
@@ -10,6 +10,36 @@ use Swis\JsonApi\Client\Meta;
 interface OneRelationInterface
 {
     /**
+     * @param \Swis\JsonApi\Client\Interfaces\ItemInterface|null $data
+     */
+    public function setData(?ItemInterface $data);
+
+    /**
+     * @return \Swis\JsonApi\Client\Interfaces\ItemInterface|null
+     */
+    public function getData(): ?ItemInterface;
+
+    /**
+     * @return bool
+     */
+    public function hasData(): bool;
+
+    /**
+     * @param \Swis\JsonApi\Client\Interfaces\ItemInterface|null $included
+     */
+    public function setIncluded(?ItemInterface $included);
+
+    /**
+     * @return \Swis\JsonApi\Client\Interfaces\ItemInterface|null
+     */
+    public function getIncluded(): ?ItemInterface;
+
+    /**
+     * @return bool
+     */
+    public function hasIncluded(): bool;
+
+    /**
      * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $included
      *
      * @return static
@@ -22,14 +52,14 @@ interface OneRelationInterface
     public function dissociate();
 
     /**
-     * @return bool
-     */
-    public function hasIncluded(): bool;
-
-    /**
      * @return \Swis\JsonApi\Client\Interfaces\ItemInterface|null
      */
-    public function getIncluded(): ?ItemInterface;
+    public function getAssociated(): ?ItemInterface;
+
+    /**
+     * @return bool
+     */
+    public function hasAssociated(): bool;
 
     /**
      * @param bool $omitIncluded

--- a/src/Item.php
+++ b/src/Item.php
@@ -248,26 +248,26 @@ class Item implements ArrayAccess, Arrayable, Jsonable, JsonSerializable, ItemIn
         $relationships = [];
 
         foreach ($this->getRelations() as $name => $relation) {
-            if (!$relation->hasIncluded()) {
+            if (!$relation->hasAssociated()) {
                 continue;
             }
 
             if ($relation instanceof OneRelationInterface) {
                 $relationships[$name]['data'] = null;
 
-                if ($relation->getIncluded() !== null) {
+                if ($relation->getAssociated() !== null) {
                     $relationships[$name]['data'] = [
-                        'type' => $relation->getIncluded()->getType(),
-                        'id' => $relation->getIncluded()->getId(),
+                        'type' => $relation->getAssociated()->getType(),
+                        'id' => $relation->getAssociated()->getId(),
                     ];
-                    if ($relation->getIncluded()->getMeta()) {
-                        $relationships[$name]['data']['meta'] = $relation->getIncluded()->getMeta()->toArray();
+                    if ($relation->getAssociated()->getMeta()) {
+                        $relationships[$name]['data']['meta'] = $relation->getAssociated()->getMeta()->toArray();
                     }
                 }
             } elseif ($relation instanceof ManyRelationInterface) {
                 $relationships[$name]['data'] = [];
 
-                foreach ($relation->getIncluded() as $item) {
+                foreach ($relation->getAssociated() as $item) {
                     $data = [
                         'type' => $item->getType(),
                         'id' => $item->getId(),

--- a/src/Relations/AbstractManyRelation.php
+++ b/src/Relations/AbstractManyRelation.php
@@ -8,16 +8,37 @@ use Swis\JsonApi\Client\Collection;
 use Swis\JsonApi\Client\Interfaces\ManyRelationInterface;
 
 /**
+ * @property \Swis\JsonApi\Client\Collection|false|null $data
  * @property \Swis\JsonApi\Client\Collection|false|null $included
  */
 abstract class AbstractManyRelation extends AbstractRelation implements ManyRelationInterface
 {
     /**
+     * @param \Swis\JsonApi\Client\Collection|null $data
+     *
+     * @return $this
+     */
+    public function setData(?Collection $data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * @return \Swis\JsonApi\Client\Collection|null
+     */
+    public function getData(): ?Collection
+    {
+        return $this->data ?: null;
+    }
+
+    /**
      * @param \Swis\JsonApi\Client\Collection $included
      *
      * @return $this
      */
-    public function associate(Collection $included)
+    public function setIncluded(Collection $included)
     {
         $this->included = $included;
 
@@ -30,6 +51,33 @@ abstract class AbstractManyRelation extends AbstractRelation implements ManyRela
     public function getIncluded(): Collection
     {
         return $this->included ?: new Collection();
+    }
+
+    /**
+     * @param \Swis\JsonApi\Client\Collection $included
+     *
+     * @return $this
+     */
+    public function associate(Collection $included)
+    {
+        return $this->setData($included)
+            ->setIncluded($included);
+    }
+
+    /**
+     * @return \Swis\JsonApi\Client\Collection
+     */
+    public function getAssociated(): Collection
+    {
+        if ($this->hasIncluded()) {
+            return $this->getIncluded();
+        }
+
+        if ($this->hasData()) {
+            return $this->getData();
+        }
+
+        return new Collection();
     }
 
     /**

--- a/src/Relations/AbstractOneRelation.php
+++ b/src/Relations/AbstractOneRelation.php
@@ -8,16 +8,37 @@ use Swis\JsonApi\Client\Interfaces\ItemInterface;
 use Swis\JsonApi\Client\Interfaces\OneRelationInterface;
 
 /**
+ * @property \Swis\JsonApi\Client\Interfaces\ItemInterface|false|null $data
  * @property \Swis\JsonApi\Client\Interfaces\ItemInterface|false|null $included
  */
 abstract class AbstractOneRelation extends AbstractRelation implements OneRelationInterface
 {
     /**
-     * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $included
+     * @param \Swis\JsonApi\Client\Interfaces\ItemInterface|null $data
      *
      * @return $this
      */
-    public function associate(ItemInterface $included)
+    public function setData(?ItemInterface $data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * @return \Swis\JsonApi\Client\Interfaces\ItemInterface|null
+     */
+    public function getData(): ?ItemInterface
+    {
+        return $this->data ?: null;
+    }
+
+    /**
+     * @param \Swis\JsonApi\Client\Interfaces\ItemInterface|null $included
+     *
+     * @return $this
+     */
+    public function setIncluded(?ItemInterface $included)
     {
         $this->included = $included;
 
@@ -30,5 +51,32 @@ abstract class AbstractOneRelation extends AbstractRelation implements OneRelati
     public function getIncluded(): ?ItemInterface
     {
         return $this->included ?: null;
+    }
+
+    /**
+     * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $included
+     *
+     * @return $this
+     */
+    public function associate(ItemInterface $included)
+    {
+        return $this->setData($included)
+            ->setIncluded($included);
+    }
+
+    /**
+     * @return \Swis\JsonApi\Client\Interfaces\ItemInterface|null
+     */
+    public function getAssociated(): ?ItemInterface
+    {
+        if ($this->hasIncluded()) {
+            return $this->getIncluded();
+        }
+
+        if ($this->hasData()) {
+            return $this->getData();
+        }
+
+        return null;
     }
 }

--- a/src/Relations/AbstractRelation.php
+++ b/src/Relations/AbstractRelation.php
@@ -15,6 +15,11 @@ abstract class AbstractRelation
     /**
      * @var \Swis\JsonApi\Client\Interfaces\DataInterface|false|null
      */
+    protected $data = false;
+
+    /**
+     * @var \Swis\JsonApi\Client\Interfaces\DataInterface|false|null
+     */
     protected $included = false;
 
     /**
@@ -23,13 +28,11 @@ abstract class AbstractRelation
     protected $omitIncluded = false;
 
     /**
-     * @return $this
+     * @return bool
      */
-    public function dissociate()
+    public function hasData(): bool
     {
-        $this->included = null;
-
-        return $this;
+        return $this->data !== false;
     }
 
     /**
@@ -38,6 +41,25 @@ abstract class AbstractRelation
     public function hasIncluded(): bool
     {
         return $this->included !== false;
+    }
+
+    /**
+     * @return $this
+     */
+    public function dissociate()
+    {
+        $this->data = null;
+        $this->included = null;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasAssociated(): bool
+    {
+        return $this->hasData() || $this->hasIncluded();
     }
 
     /**

--- a/tests/Parsers/DocumentParserTest.php
+++ b/tests/Parsers/DocumentParserTest.php
@@ -602,6 +602,60 @@ class DocumentParserTest extends TestCase
     /**
      * @test
      */
+    public function itParsesMetaInRelationshipDataAndIncluded()
+    {
+        $typeMapper = new TypeMapper();
+        $typeMapper->setMapping('master', MasterItem::class);
+        $typeMapper->setMapping('child', ChildItem::class);
+        $parser = DocumentParser::create($typeMapper);
+
+        $document = $parser->parse(
+            json_encode(
+                [
+                    'data' => [
+                        'type' => 'master',
+                        'id' => '1',
+                        'attributes' => [
+                            'foo' => 'bar',
+                        ],
+                        'relationships' => [
+                            'child' => [
+                                'data' => [
+                                    'type' => 'child',
+                                    'id' => '1',
+                                    'meta' => [
+                                        'a' => 'foo',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                    'included' => [
+                        [
+                            'type' => 'child',
+                            'id' => '1',
+                            'attributes' => [
+                                'foo' => 'baz',
+                            ],
+                            'meta' => [
+                                'b' => 'bar',
+                            ],
+                        ],
+                    ],
+                ]
+            )
+        );
+
+        static::assertInstanceOf(Meta::class, $document->getData()->child()->getData()->getMeta());
+        static::assertInstanceOf(Meta::class, $document->getData()->child()->getIncluded()->getMeta());
+
+        static::assertEquals(new Meta(['a' => 'foo']), $document->getData()->child()->getData()->getMeta());
+        static::assertEquals(new Meta(['b' => 'bar']), $document->getData()->child()->getIncluded()->getMeta());
+    }
+
+    /**
+     * @test
+     */
     public function itParsesJsonapi()
     {
         $parser = DocumentParser::create();

--- a/tests/Parsers/ItemParserTest.php
+++ b/tests/Parsers/ItemParserTest.php
@@ -659,7 +659,25 @@ class ItemParserTest extends TestCase
     /**
      * @test
      */
-    public function itParsesMetaInData()
+    public function itParsesMetaInRelationship()
+    {
+        $typeMapper = new TypeMapper();
+        $typeMapper->setMapping('child', ChildItem::class);
+        $typeMapper->setMapping('master', MasterItem::class);
+        $parser = $this->getItemParser($typeMapper);
+
+        $item = $parser->parse($this->getJsonApiItemMock('master', '1'));
+
+        $meta = $item->getRelation('child')->getMeta();
+        static::assertInstanceOf(Meta::class, $meta);
+
+        $this->assertEquals('bar', $meta->foo);
+    }
+
+    /**
+     * @test
+     */
+    public function itParsesMetaInRelationshipData()
     {
         $typeMapper = new TypeMapper();
         $typeMapper->setMapping('child', ChildItem::class);
@@ -801,19 +819,19 @@ class ItemParserTest extends TestCase
                         'type' => 'child',
                         'id' => '9',
                         'meta' => [
-                          'alt' => '',
-                          'width' => 1920,
-                          'height' => 1280,
-                          'imageDerivatives' => [
-                            'links' => [
-                              'header' => [
-                                'href' => 'https://example.com/image/header/about-us.jpeg',
-                                'meta' => [
-                                  'rel' => 'drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative',
+                            'alt' => '',
+                            'width' => 1920,
+                            'height' => 1280,
+                            'imageDerivatives' => [
+                                'links' => [
+                                    'header' => [
+                                        'href' => 'https://example.com/image/header/about-us.jpeg',
+                                        'meta' => [
+                                            'rel' => 'drupal://jsonapi/extensions/consumer_image_styles/links/relation-types/#derivative',
+                                        ],
+                                    ],
                                 ],
-                              ],
                             ],
-                          ],
                         ],
                     ],
                     'links' => [


### PR DESCRIPTION
## Description

I've changed the relationship classes so they can store both data and included.

## Motivation and context

#89 fixed a bug where meta in relationship data was ignored. However, when an item that has meta in it's relationship data is included, it is overwritten by the item from the included. Removing access to that meta.

### Use case
Given the following JSON:
```json
{
	"data": {
		"type": "parent",
		"id": "1",
		"attributes": {
			"foo": "bar"
		},
		"relationships": {
			"child": {
				"data": {
					"type": "child",
					"id": "1",
					"meta": {
						"a": "foo"
					}
				}
			}
		}
	},
	"included": [{
		"type": "child",
		"id": "1",
		"attributes": {
			"foo": "baz"
		}
	}]
}
```
It was not possible to use the meta from the relationship (`{"a": "foo"}`), as the entire item would be overwritten by the included item. So when you get the meta from the related item, you get `null` as there is no meta in included.

### New situation
`$document->getData()->getRelation('child')->getData()->getMeta()` > `{"a": "foo"}`
`$document->getData()->getRelation('child')->getIncluded()->getMeta()` or `$document->getData()->child->getMeta()` > `null`

### N.B.
To make this fix backwards compatible, a relationship's included is filled, even when the item(s) are not actually included. In the next major version, we can choose to make this more strict and only fill the included when the item is actually included.

## How has this been tested?

I've added new tests.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
