### PR TITLE
build: add support for Laravel 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,15 +10,15 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '7.4', '8.0', '8.1' ]
-        laravel: [ '6.*', '7.*', '8.*', '9.*' ]
+        laravel: [ '8.*', '9.*', '10.*' ]
         stability: [ prefer-lowest, prefer-stable ]
         exclude:
-          - laravel: '6.*'
-            php: '8.1'
-          - laravel: '7.*'
-            php: '8.1'
           - laravel: '9.*'
             php: '7.4'
+          - laravel: '10.*'
+            php: '7.4'
+          - laravel: '10.*'
+            php: '8.0'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "illuminate/contracts:${{ matrix.laravel }}" "swisnl/illuminate-collections:${{ matrix.laravel }}" --no-interaction --no-update
+          composer require "illuminate/collections:${{ matrix.laravel }}" "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+* Added support for Laravel 10.
+
 ### Removed
 
 * Dropped PHP <7.4 support.
+* Dropped Laravel <8 support.
 
 ## [2.2.0] - 2022-09-08
 

--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,14 @@
     "require": {
         "php": "^7.4|^8.0",
         "ext-json": "*",
-        "illuminate/contracts": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/collections": "^8.0|^9.0|^10.0",
+        "illuminate/contracts": "^8.0|^9.0|^10.0",
         "php-http/discovery": "^1.9",
         "psr/http-client": "^1.0",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-factory-implementation": "^1.0",
-        "psr/http-message": "^1.0",
-        "swisnl/illuminate-collections": "^6.0|^7.0|^8.0|^9.0"
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",


### PR DESCRIPTION
## Description

I've added support for Laravel 10 and dropped support for Laravel <8.

## Motivation and context

Laravel 10 is almost there! I had to drop support for Laravel <8 as `swisnl/illuminate-collections` is deprecated and we should move to `illuminate/collections` instead, which is Laravel >=8.

## How has this been tested?

I've updated the CI matrix to include Laravel 10.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.
