### PR TITLE
Add ability to send headers through repositories

### DIFF
--- a/src/Actions/Create.php
+++ b/src/Actions/Create.php
@@ -11,14 +11,16 @@ trait Create
     /**
      * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $item
      * @param array                                         $parameters
+     * @param array                                         $headers
      *
      * @return \Swis\JsonApi\Client\Interfaces\DocumentInterface
      */
-    public function create(ItemInterface $item, array $parameters = [])
+    public function create(ItemInterface $item, array $parameters = [], array $headers = [])
     {
         return $this->getClient()->post(
             $this->getEndpoint().'?'.http_build_query($parameters),
-            $this->documentFactory->make($item)
+            $this->documentFactory->make($item),
+            $headers,
         );
     }
 }

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -9,11 +9,12 @@ trait Delete
     /**
      * @param string $id
      * @param array  $parameters
+     * @param array  $headers
      *
      * @return \Swis\JsonApi\Client\Interfaces\DocumentInterface
      */
-    public function delete(string $id, array $parameters = [])
+    public function delete(string $id, array $parameters = [], array $headers = [])
     {
-        return $this->getClient()->delete($this->getEndpoint().'/'.urlencode($id).'?'.http_build_query($parameters));
+        return $this->getClient()->delete($this->getEndpoint().'/'.urlencode($id).'?'.http_build_query($parameters), $headers);
     }
 }

--- a/src/Actions/FetchMany.php
+++ b/src/Actions/FetchMany.php
@@ -8,11 +8,12 @@ trait FetchMany
 {
     /**
      * @param array $parameters
+     * @param array $headers
      *
      * @return \Swis\JsonApi\Client\Interfaces\DocumentInterface
      */
-    public function all(array $parameters = [])
+    public function all(array $parameters = [], array $headers = [])
     {
-        return $this->getClient()->get($this->getEndpoint().'?'.http_build_query($parameters));
+        return $this->getClient()->get($this->getEndpoint().'?'.http_build_query($parameters), $headers);
     }
 }

--- a/src/Actions/FetchOne.php
+++ b/src/Actions/FetchOne.php
@@ -9,11 +9,12 @@ trait FetchOne
     /**
      * @param string $id
      * @param array  $parameters
+     * @param array  $headers
      *
      * @return \Swis\JsonApi\Client\Interfaces\DocumentInterface
      */
-    public function find(string $id, array $parameters = [])
+    public function find(string $id, array $parameters = [], array $headers = [])
     {
-        return $this->getClient()->get($this->getEndpoint().'/'.urlencode($id).'?'.http_build_query($parameters));
+        return $this->getClient()->get($this->getEndpoint().'/'.urlencode($id).'?'.http_build_query($parameters), $headers);
     }
 }

--- a/src/Actions/Save.php
+++ b/src/Actions/Save.php
@@ -14,15 +14,16 @@ trait Save
     /**
      * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $item
      * @param array                                         $parameters
+     * @param array                                         $headers
      *
      * @return \Swis\JsonApi\Client\Interfaces\DocumentInterface
      */
-    public function save(ItemInterface $item, array $parameters = [])
+    public function save(ItemInterface $item, array $parameters = [], array $headers = [])
     {
         if ($item->isNew()) {
-            return $this->saveNew($item, $parameters);
+            return $this->saveNew($item, $parameters, $headers);
         }
 
-        return $this->saveExisting($item, $parameters);
+        return $this->saveExisting($item, $parameters, $headers);
     }
 }

--- a/src/Actions/TakeOne.php
+++ b/src/Actions/TakeOne.php
@@ -8,11 +8,12 @@ trait TakeOne
 {
     /**
      * @param array $parameters
+     * @param array $headers
      *
      * @return \Swis\JsonApi\Client\Interfaces\DocumentInterface
      */
-    public function take(array $parameters = [])
+    public function take(array $parameters = [], array $headers = [])
     {
-        return $this->getClient()->get($this->getEndpoint().'?'.http_build_query($parameters));
+        return $this->getClient()->get($this->getEndpoint().'?'.http_build_query($parameters), $headers);
     }
 }

--- a/src/Actions/Update.php
+++ b/src/Actions/Update.php
@@ -11,14 +11,16 @@ trait Update
     /**
      * @param \Swis\JsonApi\Client\Interfaces\ItemInterface $item
      * @param array                                         $parameters
+     * @param array                                         $headers
      *
      * @return \Swis\JsonApi\Client\Interfaces\DocumentInterface
      */
-    public function update(ItemInterface $item, array $parameters = [])
+    public function update(ItemInterface $item, array $parameters = [], array $headers = [])
     {
         return $this->getClient()->patch(
             $this->getEndpoint().'/'.urlencode($item->getId()).'?'.http_build_query($parameters),
-            $this->documentFactory->make($item)
+            $this->documentFactory->make($item),
+            $headers,
         );
     }
 }

--- a/tests/RepositoryTest.php
+++ b/tests/RepositoryTest.php
@@ -50,12 +50,12 @@ class RepositoryTest extends TestCase
 
         $client->expects($this->once())
             ->method('get')
-            ->with('mocks?foo=bar')
+            ->with('mocks?foo=bar', ['Test-Header' => 'Foo-Bar'])
             ->willReturn($document);
 
         $repository = new MockRepository($client, new DocumentFactory());
 
-        $this->assertSame($document, $repository->all(['foo' => 'bar']));
+        $this->assertSame($document, $repository->all(['foo' => 'bar'], ['Test-Header' => 'Foo-Bar']));
     }
 
     /**
@@ -70,12 +70,12 @@ class RepositoryTest extends TestCase
 
         $client->expects($this->once())
             ->method('get')
-            ->with('mocks?foo=bar')
+            ->with('mocks?foo=bar', ['Test-Header' => 'Foo-Bar'])
             ->willReturn($document);
 
         $repository = new MockRepository($client, new DocumentFactory());
 
-        $this->assertSame($document, $repository->take(['foo' => 'bar']));
+        $this->assertSame($document, $repository->take(['foo' => 'bar'], ['Test-Header' => 'Foo-Bar']));
     }
 
     /**
@@ -90,12 +90,12 @@ class RepositoryTest extends TestCase
 
         $client->expects($this->once())
             ->method('get')
-            ->with('mocks/1?foo=bar')
+            ->with('mocks/1?foo=bar', ['Test-Header' => 'Foo-Bar'])
             ->willReturn($document);
 
         $repository = new MockRepository($client, new DocumentFactory());
 
-        $this->assertSame($document, $repository->find('1', ['foo' => 'bar']));
+        $this->assertSame($document, $repository->find('1', ['foo' => 'bar'], ['Test-Header' => 'Foo-Bar']));
     }
 
     /**
@@ -111,12 +111,12 @@ class RepositoryTest extends TestCase
 
         $client->expects($this->once())
             ->method('post')
-            ->with('mocks?foo=bar')
+            ->with('mocks?foo=bar', $document, ['Test-Header' => 'Foo-Bar'])
             ->willReturn($document);
 
         $repository = new MockRepository($client, new DocumentFactory());
 
-        $this->assertSame($document, $repository->save(new Item(), ['foo' => 'bar']));
+        $this->assertSame($document, $repository->save(new Item(), ['foo' => 'bar'], ['Test-Header' => 'Foo-Bar']));
     }
 
     /**
@@ -132,12 +132,12 @@ class RepositoryTest extends TestCase
 
         $client->expects($this->once())
             ->method('patch')
-            ->with('mocks/1?foo=bar')
+            ->with('mocks/1?foo=bar', $document, ['Test-Header' => 'Foo-Bar'])
             ->willReturn($document);
 
         $repository = new MockRepository($client, new DocumentFactory());
 
-        $this->assertSame($document, $repository->save((new Item())->setId('1'), ['foo' => 'bar']));
+        $this->assertSame($document, $repository->save((new Item())->setId('1'), ['foo' => 'bar'], ['Test-Header' => 'Foo-Bar']));
     }
 
     /**
@@ -152,11 +152,11 @@ class RepositoryTest extends TestCase
 
         $client->expects($this->once())
             ->method('delete')
-            ->with('mocks/1?foo=bar')
+            ->with('mocks/1?foo=bar', ['Test-Header' => 'Foo-Bar'])
             ->willReturn($document);
 
         $repository = new MockRepository($client, new DocumentFactory());
 
-        $this->assertSame($document, $repository->delete('1', ['foo' => 'bar']));
+        $this->assertSame($document, $repository->delete('1', ['foo' => 'bar'], ['Test-Header' => 'Foo-Bar']));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Accept a new `array $headers = []` argument for every method used in repositories (default to an empty array for backward compatibility). Then forward those arguments to the underlying DocumentClient class, which already accepts them.

## Motivation and context

Closes https://github.com/swisnl/json-api-client/issues/102

## How has this been tested?

Tested the headers inputs in `RepositoryTest`

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
